### PR TITLE
feat: transcript enhancement suite (data layer + components)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ TalkTrack/
   requirements.txt                     # Dependencies
   app/
     main_window.py                     # Main window + orchestration
+    audio/
+      __init__.py                      # Package init
+      segment_player.py               # Audio clip playback for transcript segments
     recording/
       audio_capture.py                 # AudioStream, DualAudioCapture (legacy + per-app modes)
       process_audio_capture.py         # ProcessCaptureStream, ProcessAudioCapture (Win11 per-PID)
@@ -35,9 +38,12 @@ TalkTrack/
     ui/
       source_selector.py              # Mic dropdown + per-app picker (Win11) or legacy loopback (Win10)
       recording_controls.py           # Record/Pause/Stop buttons + timer
+      recording_header.py             # Recording info display with rename
+      segment_widget.py               # Interactive transcript segment row
       settings_dialog.py              # Settings dialog with tabs
+      speaker_name_panel.py           # Collapsible speaker name mapping panel
       status_panel.py                 # System status dialog (dependency health checks)
-      transcript_viewer.py            # Display + export transcripts
+      transcript_viewer.py            # Display + export transcripts (with interactive segments)
       notes_panel.py                  # Call notes with timestamps
       recordings_list.py              # Past recordings browser
     utils/
@@ -52,6 +58,11 @@ TalkTrack/
     test_process_audio_capture.py     # Mixer and capture stream tests
     test_dual_audio_capture.py        # Per-app mode integration tests
     test_dependency_checker.py        # Dependency checker tests
+    test_transcriber.py               # TranscriptSegment/TranscriptResult tests
+    test_segment_player.py            # Audio clip playback tests
+    test_recording_header.py          # RecordingHeader helper tests
+    test_speaker_name_panel.py        # SpeakerNamePanel helper tests
+    test_segment_widget.py            # SegmentWidget helper tests
   docs/plans/                         # Design docs and implementation plans
   recordings/                         # Output directory
 ```
@@ -67,10 +78,13 @@ TalkTrack/
   - Simple mode (no setup): labels "You" vs "Remote" based on mic vs system channels
   - Full diarization (pyannote.audio): identifies individual speakers
 - **System Status Panel:** startup dependency health check (Help > System Status)
+- **Interactive transcript viewer:** per-segment audio playback, inline text editing, speaker name mapping
+- **Speaker naming:** assign friendly names to diarized speakers, saved per recording
+- **Recording header:** shows loaded recording info (name, date, duration, speakers) with rename
 - Color-coded transcript with speaker labels and timestamps
-- Export transcript to TXT, SRT (subtitles), or JSON
+- Export transcript to TXT, SRT (subtitles), or JSON with speaker names
 - Call notes with timestamp insertion
-- Browse and replay past recordings
+- Browse and replay past recordings (with friendly names)
 - Settings for model size, sample rate, output format (WAV/MP3)
 - Dark theme UI (Catppuccin Mocha palette)
 
@@ -110,6 +124,15 @@ TalkTrack/
 - `SystemStatusDialog` shows results with actionable fix suggestions
 - Auto-shows on startup if critical checks fail
 - Accessible via Help > System Status
+
+### Transcript Enhancement Suite
+- `SegmentWidget`: Interactive row per transcript segment — play button, timestamp, speaker label (clickable), editable text, edit indicator
+- `SpeakerNamePanel`: Collapsible panel mapping speaker IDs (e.g., SPEAKER_00) to friendly names, with color swatches
+- `RecordingHeader`: Shows loaded recording info with inline rename capability
+- `SegmentPlayer`: Plays audio clips for individual segments using sounddevice, caches loaded audio
+- Speaker names stored per recording in `speaker_names.json`, separate from `transcript.json`
+- `TranscriptSegment.original_text` tracks pre-edit text for undo support
+- Signal flow: SegmentWidget → TranscriptViewer → MainWindow (saves to disk)
 
 ### Configuration
 - Stored at ~/.talktrack/settings.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,134 @@
+# TalkTrack
+
+Record, transcribe, and identify speakers from your calls — all locally on your machine.
+
+TalkTrack is a Windows desktop app that captures audio from Teams, Zoom, and other call apps, then transcribes it with [Faster Whisper](https://github.com/SYSTRAN/faster-whisper) and identifies speakers with [pyannote.audio](https://github.com/pyannote/pyannote-audio). Everything runs offline — no cloud services, no data leaves your PC.
+
+![Python](https://img.shields.io/badge/Python-3.10+-blue)
+![Platform](https://img.shields.io/badge/Platform-Windows-0078D6)
+![UI](https://img.shields.io/badge/UI-PyQt6-41CD52)
+![License](https://img.shields.io/badge/License-MIT-green)
+
+## Features
+
+- **Record calls** with Record / Pause / Resume / Stop controls and a live timer
+- **Per-app audio capture** (Windows 11) — pick specific apps like Teams or Chrome
+- **System audio capture** (Windows 10+) — WASAPI loopback for all system audio
+- **Dual-channel recording** — microphone + system/app audio captured separately
+- **Local transcription** — Faster Whisper (OpenAI Whisper), no internet required
+- **Speaker diarization** — two modes:
+  - *Simple* (no setup): labels "You" vs "Remote" from mic vs system channels
+  - *Full* (pyannote.audio): identifies individual speakers with a free HuggingFace token
+- **Interactive transcript** — click any segment to replay its audio, edit text inline, assign speaker names
+- **Export** to TXT, SRT (subtitles), or JSON
+- **Call notes** with timestamp insertion
+- **Recording browser** — browse and replay past recordings
+- **Dark theme** UI (Catppuccin Mocha palette)
+- **Guided setup wizard** for HuggingFace / pyannote configuration
+
+## Quick Start
+
+### Prerequisites
+
+- Windows 10 or 11
+- Python 3.10+
+- A microphone
+
+### Install
+
+```bash
+git clone https://github.com/ObscureAintSecure/TalkTrack.git
+cd TalkTrack
+pip install -r requirements.txt
+```
+
+### Run
+
+Double-click **`start.bat`**, or:
+
+```bash
+python main.py
+```
+
+### Speaker Diarization (Optional)
+
+For multi-speaker identification, TalkTrack uses pyannote.audio which requires a free HuggingFace account. On first launch, a setup wizard walks you through the steps:
+
+1. Create a free account at [huggingface.co](https://huggingface.co/join)
+2. Accept the model license at [pyannote/speaker-diarization-community-1](https://huggingface.co/pyannote/speaker-diarization-community-1)
+3. Create an access token at [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)
+4. Paste the token into the wizard (or Settings > Transcription)
+
+Without this setup, TalkTrack still works — it just labels speakers as "You" and "Remote" based on audio channels.
+
+## Usage
+
+1. Start your call in Teams, Zoom, or any app
+2. In TalkTrack, select your microphone and the app to capture
+3. Click **Record**
+4. When done, click **Stop** — transcription starts automatically
+5. Review the transcript, assign speaker names, edit text, export
+
+**Windows 11:** Select specific apps (Teams, Chrome, etc.) in the app picker to capture only their audio.
+
+**Windows 10:** Captures all system audio via WASAPI loopback.
+
+## Settings
+
+Access via the gear icon or **Edit > Settings**:
+
+| Setting | Options | Default |
+|---------|---------|---------|
+| Whisper Model | tiny, base, small, medium, large-v3 | small |
+| Sample Rate | 16000, 44100, 48000 Hz | 16000 |
+| Output Format | WAV, MP3 | WAV |
+| Capture Mode | Per-app (Win11) or Legacy | Auto-detected |
+
+## Project Structure
+
+```
+TalkTrack/
+  main.py                    # Entry point
+  start.bat / start.ps1      # Launcher scripts
+  requirements.txt           # Dependencies
+  resources/style.qss        # Dark theme stylesheet
+  app/
+    main_window.py           # Main window + orchestration
+    audio/
+      segment_player.py      # Audio clip playback
+    recording/
+      audio_capture.py       # WASAPI capture (legacy + per-app)
+      process_audio_capture.py  # Win11 per-process capture
+      recorder.py            # Recording state machine
+    transcription/
+      transcriber.py         # Faster Whisper integration
+      diarizer.py            # Speaker diarization (pyannote)
+    ui/                      # All UI components
+    utils/                   # Config, device enumeration, helpers
+  tests/                     # Unit tests
+  recordings/                # Output directory
+```
+
+## Running Tests
+
+```bash
+python -m pytest tests/ -v
+```
+
+## Tech Stack
+
+| Component | Library |
+|-----------|---------|
+| GUI | PyQt6 |
+| Audio Capture | sounddevice, WASAPI, comtypes |
+| Transcription | faster-whisper |
+| Speaker Diarization | pyannote.audio 4.0 |
+| Deep Learning | PyTorch |
+| Audio Processing | scipy, pydub, soundfile, numpy |
+| Windows Integration | pywin32, pycaw, comtypes |
+
+## Known Limitations
+
+- **Windows only** — uses WASAPI and Windows COM APIs
+- **Per-app capture requires Windows 11** Build 22000+
+- Per-process COM capture is in active development — the pipeline structure is in place, with packet reading being completed through real-device testing

--- a/app/audio/segment_player.py
+++ b/app/audio/segment_player.py
@@ -1,0 +1,76 @@
+"""Audio segment playback using sounddevice."""
+import sounddevice as sd
+import soundfile as sf
+import numpy as np
+from PyQt6.QtCore import QObject, pyqtSignal, QTimer
+
+
+class SegmentPlayer(QObject):
+    """Plays audio clips for transcript segments using sounddevice.
+
+    Caches the loaded audio file to avoid re-reading for each segment.
+    Emits playback_finished when a clip finishes playing.
+    """
+
+    playback_finished = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._cached_path = None
+        self._cached_data = None
+        self._cached_sr = None
+        self._playing = False
+        self._check_timer = QTimer(self)
+        self._check_timer.setInterval(100)
+        self._check_timer.timeout.connect(self._check_playback)
+
+    def play_segment(self, audio_path, start_sec, end_sec):
+        """Play audio from start_sec to end_sec of the given file."""
+        self.stop()
+
+        # Load and cache audio
+        if self._cached_path != audio_path:
+            data, sr = sf.read(audio_path, dtype="float32")
+            if data.ndim > 1:
+                data = data.mean(axis=1)
+            self._cached_data = data
+            self._cached_sr = sr
+            self._cached_path = audio_path
+
+        # Extract segment
+        start_sample = int(start_sec * self._cached_sr)
+        end_sample = int(end_sec * self._cached_sr)
+        start_sample = max(0, min(start_sample, len(self._cached_data)))
+        end_sample = max(start_sample, min(end_sample, len(self._cached_data)))
+
+        segment = self._cached_data[start_sample:end_sample]
+        if len(segment) == 0:
+            return
+
+        sd.play(segment, samplerate=self._cached_sr)
+        self._playing = True
+        self._check_timer.start()
+
+    def stop(self):
+        """Stop any currently playing audio."""
+        sd.stop()
+        self._playing = False
+        self._check_timer.stop()
+
+    def is_playing(self):
+        """Return True if audio is currently playing."""
+        return self._playing
+
+    def _check_playback(self):
+        """Poll sounddevice to detect when playback finishes."""
+        stream = sd.get_stream()
+        if stream is None or not stream.active:
+            self._playing = False
+            self._check_timer.stop()
+            self.playback_finished.emit()
+
+    def clear_cache(self):
+        """Clear cached audio data."""
+        self._cached_path = None
+        self._cached_data = None
+        self._cached_sr = None

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -72,6 +72,11 @@ class MainWindow(QMainWindow):
         status_action = QAction("&System Status...", self)
         status_action.triggered.connect(self._show_system_status)
         help_menu.addAction(status_action)
+
+        diarization_setup_action = QAction("&Diarization Setup...", self)
+        diarization_setup_action.triggered.connect(self._show_diarization_setup)
+        help_menu.addAction(diarization_setup_action)
+
         help_menu.addSeparator()
 
         about_action = QAction("&About", self)
@@ -389,13 +394,13 @@ class MainWindow(QMainWindow):
                     data = json.load(f)
                 from app.transcription.transcriber import TranscriptSegment
                 result = TranscriptResult(
-                    segments=[TranscriptSegment(**s) for s in data["segments"]],
+                    segments=[TranscriptSegment.from_dict(s) for s in data["segments"]],
                     language=data.get("language", ""),
                     duration=data.get("duration", 0),
                 )
                 self.transcript_viewer.display_transcript(result, speaker_names=speaker_names)
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"[MainWindow] Failed to load transcript: {e}")
 
         # Update recording header
         self.recording_header.set_recording(
@@ -478,9 +483,19 @@ class MainWindow(QMainWindow):
         dialog = SystemStatusDialog(self.config, self)
         dialog.exec()
 
+    def _show_diarization_setup(self):
+        from app.ui.diarization_setup import DiarizationSetupWizard
+        wizard = DiarizationSetupWizard(self.config, self)
+        wizard.exec()
+
     def _check_startup_status(self):
         if SystemStatusDialog.should_show_on_startup(self.config):
             self._show_system_status()
+
+        # Auto-show diarization setup wizard if no HF token configured
+        hf_token = self.config.get("diarization", "hf_token")
+        if not hf_token:
+            QTimer.singleShot(300, self._show_diarization_setup)
 
     def _show_about(self):
         QMessageBox.about(

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -21,6 +21,7 @@ from app.ui.notes_panel import NotesPanel
 from app.ui.recordings_list import RecordingsList
 from app.ui.settings_dialog import SettingsDialog
 from app.ui.status_panel import SystemStatusDialog
+from app.ui.recording_header import RecordingHeader
 
 
 class MainWindow(QMainWindow):
@@ -110,6 +111,10 @@ class MainWindow(QMainWindow):
         right_layout = QVBoxLayout(right_panel)
         right_layout.setContentsMargins(8, 8, 8, 8)
 
+        # Recording header (above tabs)
+        self.recording_header = RecordingHeader()
+        right_layout.addWidget(self.recording_header)
+
         self.tabs = QTabWidget()
 
         # Transcript tab
@@ -149,6 +154,13 @@ class MainWindow(QMainWindow):
 
         # Recordings list
         self.recordings_list.recording_selected.connect(self._on_recording_selected)
+
+        # Recording header
+        self.recording_header.name_changed.connect(self._on_recording_renamed)
+
+        # Transcript editing
+        self.transcript_viewer.transcript_changed.connect(self._save_transcript)
+        self.transcript_viewer.speaker_names_changed.connect(self._save_speaker_names)
 
     def _start_recording(self):
         mic = self.source_selector.get_selected_mic()
@@ -224,6 +236,9 @@ class MainWindow(QMainWindow):
 
         # Switch to transcript tab
         self.tabs.setCurrentWidget(self.transcript_viewer)
+
+        # Update recording header
+        self.recording_header.set_recording(session)
 
         # Auto-start transcription if audio available
         if audio_for_transcript:
@@ -318,20 +333,30 @@ class MainWindow(QMainWindow):
 
     def _display_final_transcript(self, result):
         self.transcript_viewer.hide_progress()
-        self.transcript_viewer.display_transcript(result)
+
+        # Load speaker names if available
+        speaker_names = {}
+        if self._current_session:
+            names_path = Path(self._current_session["directory"]) / "speaker_names.json"
+            if names_path.exists():
+                try:
+                    with open(names_path, "r", encoding="utf-8") as f:
+                        speaker_names = json.load(f)
+                except (json.JSONDecodeError, OSError):
+                    pass
+
+        self.transcript_viewer.display_transcript(result, speaker_names=speaker_names)
         self.status_label.setText("Transcription complete.")
 
-        # Save transcript to session directory
+        # Update recording header with speaker count
         if self._current_session:
-            transcript_path = Path(self._current_session["directory"]) / "transcript.json"
-            with open(transcript_path, "w", encoding="utf-8") as f:
-                json.dump(result.to_dict(), f, indent=2, ensure_ascii=False)
+            self.recording_header.set_recording(
+                self._current_session,
+                speaker_count=self.transcript_viewer.get_speaker_count()
+            )
 
-            txt_path = Path(self._current_session["directory"]) / "transcript.txt"
-            with open(txt_path, "w", encoding="utf-8") as f:
-                f.write(result.to_text())
-
-            self.recordings_list.refresh()
+        # Save transcript
+        self._save_transcript()
 
     def _on_transcription_error(self, error_msg):
         self.transcript_viewer.hide_progress()
@@ -346,6 +371,16 @@ class MainWindow(QMainWindow):
         audio_path = audio_files.get("combined") or audio_files.get("system") or audio_files.get("mic")
         self.transcript_viewer.set_audio_path(audio_path)
 
+        # Load speaker names
+        speaker_names = {}
+        names_path = Path(metadata["directory"]) / "speaker_names.json"
+        if names_path.exists():
+            try:
+                with open(names_path, "r", encoding="utf-8") as f:
+                    speaker_names = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                pass
+
         # Load existing transcript if available
         transcript_path = Path(metadata["directory"]) / "transcript.json"
         if transcript_path.exists():
@@ -358,15 +393,69 @@ class MainWindow(QMainWindow):
                     language=data.get("language", ""),
                     duration=data.get("duration", 0),
                 )
-                self.transcript_viewer.display_transcript(result)
+                self.transcript_viewer.display_transcript(result, speaker_names=speaker_names)
             except Exception:
                 pass
+
+        # Update recording header
+        self.recording_header.set_recording(
+            metadata,
+            speaker_count=self.transcript_viewer.get_speaker_count()
+        )
 
         # Load notes
         self.notes_panel.set_session_dir(metadata["directory"])
 
         # Switch to transcript tab
         self.tabs.setCurrentWidget(self.transcript_viewer)
+
+    def _save_transcript(self):
+        """Save current transcript to session directory."""
+        if not self._current_session or not self.transcript_viewer._transcript:
+            return
+        result = self.transcript_viewer._transcript
+        names = self.transcript_viewer._speaker_names
+
+        transcript_path = Path(self._current_session["directory"]) / "transcript.json"
+        with open(transcript_path, "w", encoding="utf-8") as f:
+            json.dump(result.to_dict(speaker_names=names), f, indent=2, ensure_ascii=False)
+
+        txt_path = Path(self._current_session["directory"]) / "transcript.txt"
+        with open(txt_path, "w", encoding="utf-8") as f:
+            f.write(result.to_text(speaker_names=names))
+
+        self.recordings_list.refresh()
+
+    def _save_speaker_names(self, names):
+        """Save speaker names to session directory."""
+        if not self._current_session:
+            return
+        names_path = Path(self._current_session["directory"]) / "speaker_names.json"
+        with open(names_path, "w", encoding="utf-8") as f:
+            json.dump(names, f, indent=2, ensure_ascii=False)
+
+        # Also re-save transcript with updated names
+        self._save_transcript()
+
+    def _on_recording_renamed(self, new_name):
+        """Handle recording rename from RecordingHeader."""
+        if not self._current_session:
+            return
+        self._current_session["name"] = new_name
+
+        # Update metadata.json
+        meta_path = Path(self._current_session["directory"]) / "metadata.json"
+        if meta_path.exists():
+            try:
+                with open(meta_path, "r", encoding="utf-8") as f:
+                    metadata = json.load(f)
+                metadata["name"] = new_name
+                with open(meta_path, "w", encoding="utf-8") as f:
+                    json.dump(metadata, f, indent=2, ensure_ascii=False)
+            except (json.JSONDecodeError, OSError) as e:
+                print(f"Failed to save recording name: {e}")
+
+        self.recordings_list.refresh()
 
     def _on_error(self, error_msg):
         self.status_label.setText(f"Error: {error_msg}")

--- a/app/transcription/transcriber.py
+++ b/app/transcription/transcriber.py
@@ -32,27 +32,43 @@ class TranscriptResult:
     language: str = ""
     duration: float = 0.0
 
-    def to_dict(self):
+    def _display_speaker(self, seg, speaker_names=None):
+        """Return the display name for a segment's speaker."""
+        if not seg.speaker:
+            return ""
+        if speaker_names and seg.speaker in speaker_names and speaker_names[seg.speaker]:
+            return speaker_names[seg.speaker]
+        return seg.speaker
+
+    def to_dict(self, speaker_names=None):
+        segments = []
+        for s in self.segments:
+            d = s.to_dict()
+            if speaker_names and s.speaker in speaker_names and speaker_names[s.speaker]:
+                d["speaker_name"] = speaker_names[s.speaker]
+            segments.append(d)
         return {
-            "segments": [s.to_dict() for s in self.segments],
+            "segments": segments,
             "language": self.language,
             "duration": self.duration,
         }
 
-    def to_text(self):
+    def to_text(self, speaker_names=None):
         lines = []
         for seg in self.segments:
-            speaker = f"[{seg.speaker}] " if seg.speaker else ""
+            display = self._display_speaker(seg, speaker_names)
+            speaker = f"[{display}] " if display else ""
             timestamp = f"[{_format_time(seg.start)} -> {_format_time(seg.end)}]"
             lines.append(f"{timestamp} {speaker}{seg.text}")
         return "\n".join(lines)
 
-    def to_srt(self):
+    def to_srt(self, speaker_names=None):
         lines = []
         for i, seg in enumerate(self.segments, 1):
             start_ts = _format_srt_time(seg.start)
             end_ts = _format_srt_time(seg.end)
-            speaker = f"[{seg.speaker}] " if seg.speaker else ""
+            display = self._display_speaker(seg, speaker_names)
+            speaker = f"[{display}] " if display else ""
             lines.append(f"{i}")
             lines.append(f"{start_ts} --> {end_ts}")
             lines.append(f"{speaker}{seg.text}")

--- a/app/transcription/transcriber.py
+++ b/app/transcription/transcriber.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from PyQt6.QtCore import QObject, pyqtSignal, QThread
 
 
@@ -12,6 +12,12 @@ class TranscriptSegment:
     speaker: str = ""
     confidence: float = 0.0
     original_text: str = ""
+
+    @classmethod
+    def from_dict(cls, d):
+        """Create a TranscriptSegment from a dict, ignoring unknown keys."""
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in d.items() if k in known})
 
     def to_dict(self):
         d = {

--- a/app/transcription/transcriber.py
+++ b/app/transcription/transcriber.py
@@ -11,15 +11,19 @@ class TranscriptSegment:
     text: str
     speaker: str = ""
     confidence: float = 0.0
+    original_text: str = ""
 
     def to_dict(self):
-        return {
+        d = {
             "start": self.start,
             "end": self.end,
             "text": self.text,
             "speaker": self.speaker,
             "confidence": self.confidence,
         }
+        if self.original_text:
+            d["original_text"] = self.original_text
+        return d
 
 
 @dataclass

--- a/app/ui/diarization_setup.py
+++ b/app/ui/diarization_setup.py
@@ -1,0 +1,184 @@
+"""Step-by-step diarization setup wizard for HuggingFace + pyannote."""
+import webbrowser
+
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
+    QPushButton, QCheckBox, QFrame
+)
+from PyQt6.QtCore import Qt
+
+
+HF_JOIN_URL = "https://huggingface.co/join"
+HF_MODEL_URL = "https://huggingface.co/pyannote/speaker-diarization-community-1"
+HF_TOKENS_URL = "https://huggingface.co/settings/tokens"
+
+
+class _StepWidget(QFrame):
+    """A single numbered setup step with description and optional action button."""
+
+    def __init__(self, number, title, description, button_text=None,
+                 button_url=None, parent=None):
+        super().__init__(parent)
+        self.setObjectName("wizardStep")
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(12, 10, 12, 10)
+        layout.setSpacing(12)
+
+        # Number circle
+        num_label = QLabel(str(number))
+        num_label.setObjectName("wizardStepNumber")
+        num_label.setFixedSize(32, 32)
+        num_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(num_label)
+
+        # Text column
+        text_layout = QVBoxLayout()
+        text_layout.setSpacing(4)
+
+        title_label = QLabel(title)
+        title_label.setObjectName("wizardStepTitle")
+        text_layout.addWidget(title_label)
+
+        desc_label = QLabel(description)
+        desc_label.setObjectName("wizardStepDesc")
+        desc_label.setWordWrap(True)
+        text_layout.addWidget(desc_label)
+
+        layout.addLayout(text_layout, 1)
+
+        # Action button
+        if button_text and button_url:
+            action_btn = QPushButton(button_text)
+            action_btn.setObjectName("wizardActionBtn")
+            action_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            action_btn.clicked.connect(lambda: webbrowser.open(button_url))
+            layout.addWidget(action_btn)
+
+
+class DiarizationSetupWizard(QDialog):
+    """Guided setup wizard for HuggingFace speaker diarization."""
+
+    def __init__(self, config, parent=None):
+        super().__init__(parent)
+        self.config = config
+        self.setWindowTitle("Speaker Diarization Setup")
+        self.setMinimumSize(550, 520)
+        self.setMaximumSize(650, 650)
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setSpacing(12)
+        layout.setContentsMargins(20, 20, 20, 20)
+
+        # Header
+        header = QLabel("Speaker Diarization Setup")
+        header.setObjectName("wizardHeader")
+        layout.addWidget(header)
+
+        intro = QLabel(
+            "Speaker diarization identifies who is speaking in your recordings. "
+            "It requires a free HuggingFace account. Follow these steps:"
+        )
+        intro.setWordWrap(True)
+        intro.setStyleSheet("color: #a6adc8; margin-bottom: 8px;")
+        layout.addWidget(intro)
+
+        # Step 1: Create account
+        layout.addWidget(_StepWidget(
+            number=1,
+            title="Create a HuggingFace account",
+            description="Sign up for a free account at huggingface.co. "
+                        "Skip this step if you already have one.",
+            button_text="Open HuggingFace",
+            button_url=HF_JOIN_URL,
+        ))
+
+        # Step 2: Accept model license
+        layout.addWidget(_StepWidget(
+            number=2,
+            title="Accept the model license",
+            description="The pyannote speaker diarization model requires you to "
+                        "accept its license terms. Click the link, scroll down, "
+                        "and click \"Agree and access repository\".",
+            button_text="Accept License",
+            button_url=HF_MODEL_URL,
+        ))
+
+        # Step 3: Create token
+        layout.addWidget(_StepWidget(
+            number=3,
+            title="Create an access token",
+            description="Go to your HuggingFace token settings and create a new "
+                        "token. Select \"Read\" access — that's all TalkTrack needs.",
+            button_text="Open Token Settings",
+            button_url=HF_TOKENS_URL,
+        ))
+
+        # Step 4: Paste token
+        step4_frame = QFrame()
+        step4_frame.setObjectName("wizardStep")
+        step4_layout = QHBoxLayout(step4_frame)
+        step4_layout.setContentsMargins(12, 10, 12, 10)
+        step4_layout.setSpacing(12)
+
+        num4 = QLabel("4")
+        num4.setObjectName("wizardStepNumber")
+        num4.setFixedSize(32, 32)
+        num4.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        step4_layout.addWidget(num4)
+
+        token_col = QVBoxLayout()
+        token_col.setSpacing(4)
+
+        token_title = QLabel("Paste your token below")
+        token_title.setObjectName("wizardStepTitle")
+        token_col.addWidget(token_title)
+
+        self.token_edit = QLineEdit()
+        self.token_edit.setPlaceholderText("hf_xxxxxxxxxxxxxxxxxxxx")
+        self.token_edit.setEchoMode(QLineEdit.EchoMode.Password)
+
+        # Pre-fill if token already exists
+        existing_token = self.config.get("diarization", "hf_token") or ""
+        if existing_token:
+            self.token_edit.setText(existing_token)
+
+        token_col.addWidget(self.token_edit)
+        step4_layout.addLayout(token_col, 1)
+
+        layout.addWidget(step4_frame)
+
+        # Enable checkbox
+        self.enable_check = QCheckBox("Enable speaker diarization")
+        self.enable_check.setChecked(True)
+        self.enable_check.setStyleSheet("margin-top: 4px; margin-left: 4px;")
+        layout.addWidget(self.enable_check)
+
+        layout.addStretch()
+
+        # Buttons
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+
+        skip_btn = QPushButton("Skip")
+        skip_btn.clicked.connect(self.reject)
+        skip_btn.setMinimumWidth(80)
+        btn_layout.addWidget(skip_btn)
+
+        save_btn = QPushButton("Save && Enable")
+        save_btn.setObjectName("wizardSaveBtn")
+        save_btn.clicked.connect(self._save_and_close)
+        save_btn.setMinimumWidth(120)
+        btn_layout.addWidget(save_btn)
+
+        layout.addLayout(btn_layout)
+
+    def _save_and_close(self):
+        token = self.token_edit.text().strip()
+        if token:
+            self.config.set("diarization", "hf_token", token)
+        self.config.set("diarization", "enabled", self.enable_check.isChecked())
+        self.config.save()
+        self.accept()

--- a/app/ui/recording_header.py
+++ b/app/ui/recording_header.py
@@ -1,0 +1,133 @@
+"""Recording info header with rename capability."""
+import json
+from pathlib import Path
+
+from PyQt6.QtWidgets import (
+    QWidget, QHBoxLayout, QVBoxLayout, QLabel, QLineEdit, QPushButton
+)
+from PyQt6.QtCore import Qt, pyqtSignal
+
+
+def _display_name_from_metadata(metadata):
+    """Extract display name from metadata, falling back to directory name."""
+    name = metadata.get("name", "")
+    if name:
+        return name
+    directory = metadata.get("directory", "")
+    return Path(directory).name if directory else "Untitled Recording"
+
+
+def _format_duration(seconds):
+    """Format seconds as human-readable duration string."""
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    if h > 0:
+        return f"{h}h {m}m {s}s"
+    elif m > 0:
+        return f"{m}m {s}s"
+    return f"{s}s"
+
+
+class RecordingHeader(QWidget):
+    """Displays recording info (name, date, duration) with rename capability."""
+
+    name_changed = pyqtSignal(str)  # emitted when user renames the recording
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._metadata = None
+        self._editing = False
+        self._setup_ui()
+        self.hide()  # hidden until a recording is loaded
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 4)
+
+        # Top row: name + rename button
+        top_row = QHBoxLayout()
+
+        self.name_label = QLabel("")
+        self.name_label.setObjectName("recordingName")
+        self.name_label.setStyleSheet(
+            "font-size: 16px; font-weight: bold; color: #cdd6f4;"
+        )
+        top_row.addWidget(self.name_label)
+
+        self.name_edit = QLineEdit()
+        self.name_edit.setObjectName("recordingNameEdit")
+        self.name_edit.hide()
+        self.name_edit.returnPressed.connect(self._finish_rename)
+        top_row.addWidget(self.name_edit)
+
+        top_row.addStretch()
+
+        self.rename_btn = QPushButton("Rename")
+        self.rename_btn.setObjectName("renameButton")
+        self.rename_btn.setFixedWidth(70)
+        self.rename_btn.clicked.connect(self._start_rename)
+        top_row.addWidget(self.rename_btn)
+
+        layout.addLayout(top_row)
+
+        # Bottom row: date, duration, speaker count
+        self.info_label = QLabel("")
+        self.info_label.setObjectName("recordingInfo")
+        self.info_label.setStyleSheet("color: #a6adc8; font-size: 12px;")
+        layout.addWidget(self.info_label)
+
+    def set_recording(self, metadata, speaker_count=0):
+        """Display info for the given recording metadata."""
+        self._metadata = metadata
+        if metadata is None:
+            self.hide()
+            return
+
+        self.show()
+
+        name = _display_name_from_metadata(metadata)
+        self.name_label.setText(name)
+
+        # Build info line
+        parts = []
+        started = metadata.get("started_at", "")
+        if started:
+            try:
+                from datetime import datetime
+                dt = datetime.fromisoformat(started)
+                parts.append(dt.strftime("%Y-%m-%d %H:%M"))
+            except (ValueError, TypeError):
+                parts.append(started)
+
+        duration = metadata.get("duration", 0)
+        if duration:
+            parts.append(f"Duration: {_format_duration(duration)}")
+
+        if speaker_count > 0:
+            parts.append(f"{speaker_count} speaker{'s' if speaker_count != 1 else ''}")
+
+        self.info_label.setText("  |  ".join(parts))
+
+    def _start_rename(self):
+        if self._editing:
+            self._finish_rename()
+            return
+
+        self._editing = True
+        self.name_edit.setText(self.name_label.text())
+        self.name_label.hide()
+        self.name_edit.show()
+        self.name_edit.setFocus()
+        self.name_edit.selectAll()
+        self.rename_btn.setText("Save")
+
+    def _finish_rename(self):
+        self._editing = False
+        new_name = self.name_edit.text().strip()
+        if new_name:
+            self.name_label.setText(new_name)
+            self.name_changed.emit(new_name)
+        self.name_edit.hide()
+        self.name_label.show()
+        self.rename_btn.setText("Rename")

--- a/app/ui/recordings_list.py
+++ b/app/ui/recordings_list.py
@@ -71,6 +71,7 @@ class RecordingsList(QWidget):
             self._recordings.append(metadata)
 
             # Format display text
+            name = metadata.get("name", "")
             started = metadata.get("started_at", "")
             try:
                 dt = datetime.fromisoformat(started)
@@ -84,7 +85,10 @@ class RecordingsList(QWidget):
             has_transcript = (Path(metadata["directory"]) / "transcript.json").exists()
             transcript_indicator = " [T]" if has_transcript else ""
 
-            text = f"{date_str}  |  {dur_str}{transcript_indicator}"
+            if name:
+                text = f"{name}  |  {date_str}  |  {dur_str}{transcript_indicator}"
+            else:
+                text = f"{date_str}  |  {dur_str}{transcript_indicator}"
             item = QListWidgetItem(text)
             item.setData(Qt.ItemDataRole.UserRole, metadata)
             self.list_widget.addItem(item)

--- a/app/ui/segment_widget.py
+++ b/app/ui/segment_widget.py
@@ -1,0 +1,211 @@
+"""Individual transcript segment row widget."""
+from PyQt6.QtWidgets import (
+    QWidget, QHBoxLayout, QLabel, QLineEdit, QPushButton, QMenu
+)
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QAction
+
+
+# Speaker colors — must match transcript_viewer.py and speaker_name_panel.py
+SPEAKER_COLORS = [
+    "#89b4fa",  # blue
+    "#a6e3a1",  # green
+    "#fab387",  # peach
+    "#f5c2e7",  # pink
+    "#94e2d5",  # teal
+    "#f9e2af",  # yellow
+    "#cba6f7",  # mauve
+    "#f38ba8",  # red
+]
+
+
+def _format_time(seconds):
+    """Format seconds as HH:MM:SS."""
+    m, s = divmod(int(seconds), 60)
+    h, m = divmod(m, 60)
+    return f"{h:02d}:{m:02d}:{s:02d}"
+
+
+def _display_speaker(speaker_id, speaker_names):
+    """Return display name for a speaker, falling back to ID."""
+    if not speaker_id:
+        return ""
+    if speaker_names and speaker_id in speaker_names and speaker_names[speaker_id]:
+        return speaker_names[speaker_id]
+    return speaker_id
+
+
+class SegmentWidget(QWidget):
+    """A single transcript segment row: [play] [timestamp] [speaker] [text].
+
+    Supports:
+    - Play button to trigger audio playback
+    - Double-click text to edit inline
+    - Right-click context menu with "Revert to Original"
+    - Speaker label click to focus speaker name panel
+    """
+
+    play_requested = pyqtSignal(int)       # segment index
+    stop_requested = pyqtSignal()
+    text_edited = pyqtSignal(int, str)     # segment index, new text
+    text_reverted = pyqtSignal(int)        # segment index
+    speaker_clicked = pyqtSignal(str)      # speaker ID
+
+    def __init__(self, index, segment, speaker_color="#cdd6f4",
+                 speaker_name="", parent=None):
+        super().__init__(parent)
+        self._index = index
+        self._segment = segment
+        self._speaker_color = speaker_color
+        self._speaker_name = speaker_name
+        self._editing = False
+        self._playing = False
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(4, 2, 4, 2)
+        layout.setSpacing(6)
+
+        # Play button
+        self.play_btn = QPushButton("\u25b6")
+        self.play_btn.setObjectName("segmentPlayBtn")
+        self.play_btn.setFixedSize(28, 28)
+        self.play_btn.setStyleSheet(
+            "QPushButton { font-size: 11px; border-radius: 14px; "
+            "background-color: #313244; border: 1px solid #45475a; padding: 0; }"
+            "QPushButton:hover { background-color: #45475a; }"
+        )
+        self.play_btn.clicked.connect(self._on_play_clicked)
+        layout.addWidget(self.play_btn)
+
+        # Timestamp
+        start_ts = _format_time(self._segment.start)
+        end_ts = _format_time(self._segment.end)
+        self.timestamp_label = QLabel(f"[{start_ts} \u2192 {end_ts}]")
+        self.timestamp_label.setStyleSheet(
+            "color: #6c7086; font-family: Consolas; font-size: 11px;"
+        )
+        self.timestamp_label.setFixedWidth(160)
+        layout.addWidget(self.timestamp_label)
+
+        # Speaker label
+        display_name = self._speaker_name or self._segment.speaker
+        self.speaker_label = QLabel(f"{display_name}:" if display_name else "")
+        self.speaker_label.setStyleSheet(
+            f"color: {self._speaker_color}; font-weight: bold; font-size: 13px;"
+        )
+        if display_name:
+            self.speaker_label.setFixedWidth(120)
+            self.speaker_label.setCursor(Qt.CursorShape.PointingHandCursor)
+            self.speaker_label.mousePressEvent = self._on_speaker_clicked
+        else:
+            self.speaker_label.setFixedWidth(0)
+        layout.addWidget(self.speaker_label)
+
+        # Text label (normal mode)
+        self.text_label = QLabel(self._segment.text)
+        self.text_label.setStyleSheet("color: #cdd6f4; font-size: 13px;")
+        self.text_label.setWordWrap(True)
+        self.text_label.setTextInteractionFlags(Qt.TextInteractionFlag.NoTextInteraction)
+        self.text_label.mouseDoubleClickEvent = self._on_text_double_clicked
+        self.text_label.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.text_label.customContextMenuRequested.connect(self._show_context_menu)
+        layout.addWidget(self.text_label, 1)
+
+        # Text edit (edit mode) — hidden by default
+        self.text_edit = QLineEdit()
+        self.text_edit.hide()
+        self.text_edit.returnPressed.connect(self._finish_edit)
+        layout.addWidget(self.text_edit, 1)
+
+        # Edit indicator
+        self.edit_indicator = QLabel("\u270e")  # pencil icon
+        self.edit_indicator.setStyleSheet("color: #f9e2af; font-size: 12px;")
+        self.edit_indicator.setFixedWidth(16)
+        self.edit_indicator.setToolTip("This segment has been edited")
+        self.edit_indicator.setVisible(bool(self._segment.original_text))
+        layout.addWidget(self.edit_indicator)
+
+    def update_speaker(self, speaker_names):
+        """Update the displayed speaker name."""
+        display = _display_speaker(self._segment.speaker, speaker_names)
+        if display:
+            self.speaker_label.setText(f"{display}:")
+            self.speaker_label.setFixedWidth(120)
+        else:
+            self.speaker_label.setText("")
+            self.speaker_label.setFixedWidth(0)
+
+    def set_playing(self, playing):
+        """Update play button state."""
+        self._playing = playing
+        self.play_btn.setText("\u23f9" if playing else "\u25b6")
+
+    def _on_play_clicked(self):
+        if self._playing:
+            self.stop_requested.emit()
+        else:
+            self.play_requested.emit(self._index)
+
+    def _on_speaker_clicked(self, event):
+        if self._segment.speaker:
+            self.speaker_clicked.emit(self._segment.speaker)
+
+    def _on_text_double_clicked(self, event):
+        self._start_edit()
+
+    def _start_edit(self):
+        if self._editing:
+            return
+        self._editing = True
+        self.text_edit.setText(self.text_label.text())
+        self.text_label.hide()
+        self.text_edit.show()
+        self.text_edit.setFocus()
+        self.text_edit.selectAll()
+
+    def _finish_edit(self):
+        if not self._editing:
+            return
+        self._editing = False
+        new_text = self.text_edit.text().strip()
+        if new_text and new_text != self._segment.text:
+            self.text_label.setText(new_text)
+            self.text_edited.emit(self._index, new_text)
+            self.edit_indicator.setVisible(True)
+        self.text_edit.hide()
+        self.text_label.show()
+
+    def cancel_edit(self):
+        """Cancel editing without saving."""
+        if not self._editing:
+            return
+        self._editing = False
+        self.text_edit.hide()
+        self.text_label.show()
+
+    def _show_context_menu(self, pos):
+        menu = QMenu(self)
+
+        edit_action = QAction("Edit Text", self)
+        edit_action.triggered.connect(self._start_edit)
+        menu.addAction(edit_action)
+
+        if self._segment.original_text:
+            revert_action = QAction("Revert to Original", self)
+            revert_action.triggered.connect(lambda: self._revert())
+            menu.addAction(revert_action)
+
+        menu.exec(self.text_label.mapToGlobal(pos))
+
+    def _revert(self):
+        self.text_label.setText(self._segment.original_text)
+        self.edit_indicator.setVisible(False)
+        self.text_reverted.emit(self._index)
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key.Key_Escape and self._editing:
+            self.cancel_edit()
+        else:
+            super().keyPressEvent(event)

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -112,11 +112,16 @@ class SettingsDialog(QDialog):
         token_help = QLabel(
             '<a href="https://huggingface.co/settings/tokens" '
             'style="color: #89b4fa;">Get token</a> | '
-            '<a href="https://huggingface.co/pyannote/speaker-diarization-3.1" '
+            '<a href="https://huggingface.co/pyannote/speaker-diarization-community-1" '
             'style="color: #89b4fa;">Accept model terms</a>'
         )
         token_help.setOpenExternalLinks(True)
         diarization_form.addRow("", token_help)
+
+        self.setup_wizard_btn = QPushButton("Setup Wizard...")
+        self.setup_wizard_btn.setToolTip("Open the step-by-step diarization setup guide")
+        self.setup_wizard_btn.clicked.connect(self._open_setup_wizard)
+        diarization_form.addRow("", self.setup_wizard_btn)
 
         self.min_speakers_spin = QSpinBox()
         self.min_speakers_spin.setRange(0, 20)
@@ -216,6 +221,14 @@ class SettingsDialog(QDialog):
 
         self.config.save()
         self.accept()
+
+    def _open_setup_wizard(self):
+        from app.ui.diarization_setup import DiarizationSetupWizard
+        wizard = DiarizationSetupWizard(self.config, self)
+        if wizard.exec():
+            # Reload diarization settings after wizard saves
+            self.diarization_enabled.setChecked(self.config.get("diarization", "enabled"))
+            self.hf_token_edit.setText(self.config.get("diarization", "hf_token") or "")
 
     def _browse_output_dir(self):
         directory = QFileDialog.getExistingDirectory(

--- a/app/ui/source_selector.py
+++ b/app/ui/source_selector.py
@@ -88,7 +88,9 @@ class SourceSelector(QWidget):
         """Per-app audio picker (Win11)."""
         self.mode_group = QButtonGroup(self)
         self.radio_per_app = QRadioButton("Capture selected apps only")
+        self.radio_per_app.setObjectName("captureMode")
         self.radio_legacy = QRadioButton("Capture all system audio (legacy)")
+        self.radio_legacy.setObjectName("captureMode")
         self.mode_group.addButton(self.radio_per_app, 0)
         self.mode_group.addButton(self.radio_legacy, 1)
         self.radio_per_app.setChecked(True)
@@ -102,8 +104,9 @@ class SourceSelector(QWidget):
         parent_layout.addWidget(app_label)
 
         self.app_list = QListWidget()
-        self.app_list.setMinimumHeight(120)
-        self.app_list.setMaximumHeight(200)
+        self.app_list.setObjectName("appAudioList")
+        self.app_list.setMinimumHeight(100)
+        self.app_list.setMaximumHeight(180)
         parent_layout.addWidget(self.app_list)
 
         parent_layout.addWidget(self.radio_legacy)

--- a/app/ui/speaker_name_panel.py
+++ b/app/ui/speaker_name_panel.py
@@ -1,0 +1,161 @@
+"""Collapsible speaker name editing panel."""
+from PyQt6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton
+)
+from PyQt6.QtCore import Qt, pyqtSignal
+
+
+# Speaker colors — must match the list in transcript_viewer.py
+SPEAKER_COLORS = [
+    "#89b4fa",  # blue
+    "#a6e3a1",  # green
+    "#fab387",  # peach
+    "#f5c2e7",  # pink
+    "#94e2d5",  # teal
+    "#f9e2af",  # yellow
+    "#cba6f7",  # mauve
+    "#f38ba8",  # red
+]
+
+
+def _extract_speakers(segments):
+    """Extract unique speaker IDs from segments, sorted."""
+    speakers = set()
+    for seg in segments:
+        if seg.speaker:
+            speakers.add(seg.speaker)
+    return sorted(speakers)
+
+
+class SpeakerNamePanel(QWidget):
+    """Collapsible panel for mapping speaker IDs to friendly names.
+
+    Emits names_changed whenever any name is edited.
+    """
+
+    names_changed = pyqtSignal(dict)  # {speaker_id: name}
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._speaker_ids = []
+        self._name_edits = {}  # speaker_id -> QLineEdit
+        self._speaker_names = {}  # speaker_id -> name str
+        self._collapsed = False
+        self._setup_ui()
+        self.hide()  # hidden until speakers exist
+
+    def _setup_ui(self):
+        self._main_layout = QVBoxLayout(self)
+        self._main_layout.setContentsMargins(0, 0, 0, 0)
+        self._main_layout.setSpacing(4)
+
+        # Header row with toggle
+        header_row = QHBoxLayout()
+        self._toggle_btn = QPushButton("\u25bc Speakers")
+        self._toggle_btn.setObjectName("speakerPanelToggle")
+        self._toggle_btn.setFlat(True)
+        self._toggle_btn.setStyleSheet(
+            "text-align: left; font-weight: bold; color: #89b4fa; "
+            "font-size: 13px; padding: 4px 0; border: none;"
+        )
+        self._toggle_btn.clicked.connect(self._toggle_collapsed)
+        header_row.addWidget(self._toggle_btn)
+        header_row.addStretch()
+        self._main_layout.addLayout(header_row)
+
+        # Container for speaker rows (collapsible)
+        self._rows_container = QWidget()
+        self._rows_layout = QVBoxLayout(self._rows_container)
+        self._rows_layout.setContentsMargins(8, 0, 0, 0)
+        self._rows_layout.setSpacing(4)
+        self._main_layout.addWidget(self._rows_container)
+
+    def set_speakers(self, segments, speaker_names=None):
+        """Populate panel from transcript segments and optional existing names.
+
+        Args:
+            segments: list of TranscriptSegment
+            speaker_names: dict of {speaker_id: name} or None
+        """
+        self._speaker_ids = _extract_speakers(segments)
+        self._speaker_names = dict(speaker_names) if speaker_names else {}
+
+        if not self._speaker_ids:
+            self.hide()
+            return
+
+        self.show()
+        self._toggle_btn.setText(f"\u25bc Speakers ({len(self._speaker_ids)} detected)")
+
+        # Clear existing rows
+        self._name_edits.clear()
+        while self._rows_layout.count():
+            item = self._rows_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+
+        # Build rows
+        for i, speaker_id in enumerate(self._speaker_ids):
+            row_widget = QWidget()
+            row_layout = QHBoxLayout(row_widget)
+            row_layout.setContentsMargins(0, 2, 0, 2)
+
+            # Color swatch
+            color = SPEAKER_COLORS[i % len(SPEAKER_COLORS)]
+            swatch = QLabel("\u25cf")
+            swatch.setStyleSheet(f"color: {color}; font-size: 16px;")
+            swatch.setFixedWidth(20)
+            row_layout.addWidget(swatch)
+
+            # Speaker ID label
+            id_label = QLabel(speaker_id)
+            id_label.setStyleSheet("color: #a6adc8; font-size: 12px;")
+            id_label.setFixedWidth(100)
+            row_layout.addWidget(id_label)
+
+            # Arrow
+            arrow = QLabel("\u2192")
+            arrow.setStyleSheet("color: #585b70;")
+            arrow.setFixedWidth(20)
+            row_layout.addWidget(arrow)
+
+            # Name edit
+            name_edit = QLineEdit()
+            name_edit.setPlaceholderText("Enter name...")
+            name_edit.setMaximumHeight(28)
+            existing_name = self._speaker_names.get(speaker_id, "")
+            if existing_name:
+                name_edit.setText(existing_name)
+            name_edit.textChanged.connect(self._on_name_changed)
+            row_layout.addWidget(name_edit)
+
+            self._name_edits[speaker_id] = name_edit
+            self._rows_layout.addWidget(row_widget)
+
+    def get_speaker_names(self):
+        """Return current speaker name mappings (only non-empty names)."""
+        names = {}
+        for speaker_id, edit in self._name_edits.items():
+            name = edit.text().strip()
+            if name:
+                names[speaker_id] = name
+        return names
+
+    def focus_speaker(self, speaker_id):
+        """Focus the name edit for the given speaker ID."""
+        if speaker_id in self._name_edits:
+            if self._collapsed:
+                self._toggle_collapsed()
+            self._name_edits[speaker_id].setFocus()
+            self._name_edits[speaker_id].selectAll()
+
+    def _on_name_changed(self, text):
+        """Emit names_changed whenever any name field changes."""
+        self.names_changed.emit(self.get_speaker_names())
+
+    def _toggle_collapsed(self):
+        self._collapsed = not self._collapsed
+        self._rows_container.setVisible(not self._collapsed)
+        arrow = "\u25b6" if self._collapsed else "\u25bc"
+        count = len(self._speaker_ids)
+        self._toggle_btn.setText(f"{arrow} Speakers ({count} detected)")

--- a/app/ui/transcript_viewer.py
+++ b/app/ui/transcript_viewer.py
@@ -1,17 +1,17 @@
+"""Transcript viewer with interactive segment editing, playback, and speaker naming."""
 import json
 from pathlib import Path
 
 from PyQt6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QTextEdit, QPushButton,
-    QLabel, QProgressBar, QFileDialog, QComboBox
+    QWidget, QVBoxLayout, QHBoxLayout, QPushButton,
+    QLabel, QProgressBar, QFileDialog, QScrollArea
 )
 from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QTextCharFormat, QColor, QFont, QTextCursor
 
-from app.transcription.transcriber import TranscriptResult
+from app.transcription.transcriber import TranscriptResult, TranscriptSegment
 
 
-# Speaker colors for visual distinction
+# Speaker colors for visual distinction — shared constant
 SPEAKER_COLORS = [
     "#89b4fa",  # blue
     "#a6e3a1",  # green
@@ -25,21 +25,36 @@ SPEAKER_COLORS = [
 
 
 class TranscriptViewer(QWidget):
-    """Displays transcription results with speaker labels and colors."""
+    """Displays transcription results with interactive segments.
+
+    Features:
+    - Per-segment play buttons for audio clip playback
+    - Inline text editing with undo (original_text preservation)
+    - Speaker name panel for mapping IDs to friendly names
+    - Export to TXT, SRT, JSON with speaker names
+    """
 
     transcribe_requested = pyqtSignal(str)  # audio file path
+    transcript_changed = pyqtSignal()       # emitted when text or names change
+    speaker_names_changed = pyqtSignal(dict)  # emitted when speaker names change
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self._transcript = None
         self._speaker_colors = {}
+        self._speaker_names = {}
+        self._segment_widgets = []
+        self._audio_path = None
+        self._player = None
+        self._playing_index = -1
         self._setup_ui()
 
     def _setup_ui(self):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
 
-        # Header
+        # Header row: title + transcribe button
         header = QHBoxLayout()
         title = QLabel("Transcript")
         title.setObjectName("sectionHeader")
@@ -63,13 +78,39 @@ class TranscriptViewer(QWidget):
         self.status_label.hide()
         layout.addWidget(self.status_label)
 
-        # Transcript display
-        self.text_view = QTextEdit()
-        self.text_view.setReadOnly(True)
-        self.text_view.setPlaceholderText(
+        # Speaker name panel
+        from app.ui.speaker_name_panel import SpeakerNamePanel
+        self.speaker_panel = SpeakerNamePanel()
+        self.speaker_panel.names_changed.connect(self._on_speaker_names_changed)
+        layout.addWidget(self.speaker_panel)
+
+        # Scroll area for segment widgets
+        self.scroll_area = QScrollArea()
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.scroll_area.setStyleSheet(
+            "QScrollArea { border: 1px solid #313244; border-radius: 6px; "
+            "background-color: #181825; }"
+        )
+
+        self._segments_container = QWidget()
+        self._segments_container.setStyleSheet("background-color: #181825;")
+        self._segments_layout = QVBoxLayout(self._segments_container)
+        self._segments_layout.setContentsMargins(8, 8, 8, 8)
+        self._segments_layout.setSpacing(2)
+        self._segments_layout.addStretch()
+
+        self.scroll_area.setWidget(self._segments_container)
+
+        # Placeholder text
+        self._placeholder = QLabel(
             "Transcript will appear here after recording and transcription..."
         )
-        layout.addWidget(self.text_view)
+        self._placeholder.setStyleSheet("color: #585b70; padding: 20px;")
+        self._placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._segments_layout.insertWidget(0, self._placeholder)
+
+        layout.addWidget(self.scroll_area, 1)
 
         # Export buttons
         export_row = QHBoxLayout()
@@ -92,11 +133,23 @@ class TranscriptViewer(QWidget):
 
         layout.addLayout(export_row)
 
-        self._audio_path = None
+    def _ensure_player(self):
+        """Lazily create the SegmentPlayer."""
+        if self._player is None:
+            from app.audio.segment_player import SegmentPlayer
+            self._player = SegmentPlayer(self)
+            self._player.playback_finished.connect(self._on_playback_finished)
 
     def set_audio_path(self, path):
         self._audio_path = path
         self.transcribe_btn.setEnabled(path is not None)
+        if self._player:
+            self._player.stop()
+            self._player.clear_cache()
+
+    def set_speaker_names(self, names):
+        """Set speaker names from loaded speaker_names.json."""
+        self._speaker_names = dict(names) if names else {}
 
     def _on_transcribe_clicked(self):
         if self._audio_path:
@@ -111,54 +164,125 @@ class TranscriptViewer(QWidget):
         self.progress_bar.hide()
         self.status_label.hide()
 
-    def display_transcript(self, transcript):
-        """Render transcript with speaker colors."""
+    def display_transcript(self, transcript, speaker_names=None):
+        """Render transcript with interactive segment widgets."""
         self._transcript = transcript
-        self.text_view.clear()
+        if speaker_names is not None:
+            self._speaker_names = dict(speaker_names)
+
+        # Stop any playing audio
+        if self._player:
+            self._player.stop()
+        self._playing_index = -1
 
         # Assign colors to speakers
-        speakers = list(set(s.speaker for s in transcript.segments if s.speaker))
+        speakers = sorted(set(s.speaker for s in transcript.segments if s.speaker))
         self._speaker_colors = {}
-        for i, speaker in enumerate(sorted(speakers)):
+        for i, speaker in enumerate(speakers):
             self._speaker_colors[speaker] = SPEAKER_COLORS[i % len(SPEAKER_COLORS)]
 
-        cursor = self.text_view.textCursor()
+        # Clear existing segment widgets
+        self._segment_widgets.clear()
+        while self._segments_layout.count():
+            item = self._segments_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
 
-        for seg in transcript.segments:
-            # Timestamp
-            ts_format = QTextCharFormat()
-            ts_format.setForeground(QColor("#6c7086"))
-            ts_format.setFontFamily("Consolas")
-            ts_format.setFontPointSize(10)
+        # Build segment widgets
+        from app.ui.segment_widget import SegmentWidget
 
-            start_ts = self._format_time(seg.start)
-            end_ts = self._format_time(seg.end)
-            cursor.insertText(f"[{start_ts} -> {end_ts}] ", ts_format)
+        for i, seg in enumerate(transcript.segments):
+            color = self._speaker_colors.get(seg.speaker, "#cdd6f4")
+            name = self._speaker_names.get(seg.speaker, "")
 
-            # Speaker label
-            if seg.speaker:
-                spk_format = QTextCharFormat()
-                color = self._speaker_colors.get(seg.speaker, "#cdd6f4")
-                spk_format.setForeground(QColor(color))
-                spk_format.setFontWeight(QFont.Weight.Bold)
-                cursor.insertText(f"{seg.speaker}: ", spk_format)
+            widget = SegmentWidget(
+                index=i,
+                segment=seg,
+                speaker_color=color,
+                speaker_name=name,
+                parent=self._segments_container,
+            )
+            widget.play_requested.connect(self._on_play_requested)
+            widget.stop_requested.connect(self._on_stop_requested)
+            widget.text_edited.connect(self._on_text_edited)
+            widget.text_reverted.connect(self._on_text_reverted)
+            widget.speaker_clicked.connect(self._on_speaker_label_clicked)
 
-            # Text
-            text_format = QTextCharFormat()
-            text_format.setForeground(QColor("#cdd6f4"))
-            cursor.insertText(f"{seg.text}\n\n", text_format)
+            self._segment_widgets.append(widget)
+            self._segments_layout.addWidget(widget)
 
-        self.text_view.setTextCursor(cursor)
+        self._segments_layout.addStretch()
+
+        # Update speaker panel
+        self.speaker_panel.set_speakers(transcript.segments, self._speaker_names)
 
         # Enable export buttons
         self.export_txt_btn.setEnabled(True)
         self.export_srt_btn.setEnabled(True)
         self.export_json_btn.setEnabled(True)
 
-    def _format_time(self, seconds):
-        m, s = divmod(int(seconds), 60)
-        h, m = divmod(m, 60)
-        return f"{h:02d}:{m:02d}:{s:02d}"
+    def get_speaker_count(self):
+        """Return number of unique speakers in current transcript."""
+        if not self._transcript:
+            return 0
+        return len(set(s.speaker for s in self._transcript.segments if s.speaker))
+
+    # --- Audio playback ---
+
+    def _on_play_requested(self, index):
+        if not self._audio_path:
+            return
+        self._ensure_player()
+
+        # Stop previous
+        if self._playing_index >= 0 and self._playing_index < len(self._segment_widgets):
+            self._segment_widgets[self._playing_index].set_playing(False)
+
+        seg = self._transcript.segments[index]
+        self._player.play_segment(self._audio_path, seg.start, seg.end)
+        self._playing_index = index
+        self._segment_widgets[index].set_playing(True)
+
+    def _on_stop_requested(self):
+        if self._player:
+            self._player.stop()
+        if self._playing_index >= 0 and self._playing_index < len(self._segment_widgets):
+            self._segment_widgets[self._playing_index].set_playing(False)
+        self._playing_index = -1
+
+    def _on_playback_finished(self):
+        if self._playing_index >= 0 and self._playing_index < len(self._segment_widgets):
+            self._segment_widgets[self._playing_index].set_playing(False)
+        self._playing_index = -1
+
+    # --- Text editing ---
+
+    def _on_text_edited(self, index, new_text):
+        seg = self._transcript.segments[index]
+        if not seg.original_text:
+            seg.original_text = seg.text
+        seg.text = new_text
+        self.transcript_changed.emit()
+
+    def _on_text_reverted(self, index):
+        seg = self._transcript.segments[index]
+        if seg.original_text:
+            seg.text = seg.original_text
+            seg.original_text = ""
+        self.transcript_changed.emit()
+
+    # --- Speaker names ---
+
+    def _on_speaker_names_changed(self, names):
+        self._speaker_names = names
+        for widget in self._segment_widgets:
+            widget.update_speaker(names)
+        self.speaker_names_changed.emit(names)
+
+    def _on_speaker_label_clicked(self, speaker_id):
+        self.speaker_panel.focus_speaker(speaker_id)
+
+    # --- Export ---
 
     def _export(self, format_type):
         if not self._transcript:
@@ -177,12 +301,16 @@ class TranscriptViewer(QWidget):
         if not path:
             return
 
+        names = self._speaker_names
+
         if format_type == "txt":
-            content = self._transcript.to_text()
+            content = self._transcript.to_text(speaker_names=names)
         elif format_type == "srt":
-            content = self._transcript.to_srt()
+            content = self._transcript.to_srt(speaker_names=names)
         elif format_type == "json":
-            content = json.dumps(self._transcript.to_dict(), indent=2)
+            content = json.dumps(
+                self._transcript.to_dict(speaker_names=names), indent=2
+            )
 
         with open(path, "w", encoding="utf-8") as f:
             f.write(content)

--- a/app/utils/dependency_checker.py
+++ b/app/utils/dependency_checker.py
@@ -137,7 +137,7 @@ class DependencyChecker:
 
     def check_pyannote_models(self):
         """Check if pyannote speaker diarization models are cached."""
-        cache_dir = Path.home() / ".cache" / "huggingface" / "hub" / "models--pyannote--speaker-diarization-3.1"
+        cache_dir = Path.home() / ".cache" / "huggingface" / "hub" / "models--pyannote--speaker-diarization-community-1"
         if cache_dir.exists():
             return {
                 "name": "Pyannote Models",

--- a/docs/plans/2026-03-08-diarization-setup-wizard-design.md
+++ b/docs/plans/2026-03-08-diarization-setup-wizard-design.md
@@ -1,0 +1,48 @@
+# Diarization Setup Wizard — Design
+
+## Problem
+
+New users have no guidance for setting up HuggingFace + pyannote speaker diarization. The existing system status panel shows terse messages, and the settings dialog has two small hyperlinks (one pointing to the wrong model). Users must figure out the multi-step process on their own.
+
+## Solution
+
+A single-page step-by-step wizard dialog (`DiarizationSetupWizard`) that walks users through the HuggingFace setup process with numbered steps, descriptions, action buttons, and a token input field.
+
+## New File
+
+- `app/ui/diarization_setup.py` — `DiarizationSetupWizard(QDialog)`
+
+## Modified Files
+
+- `app/main_window.py` — auto-show wizard on first launch, add Help menu item
+- `app/ui/settings_dialog.py` — add "Setup Wizard..." button, fix wrong model link
+- `app/utils/dependency_checker.py` — fix wrong model cache path
+
+## Wizard Layout
+
+Single scrollable dialog with all steps visible:
+
+1. **Create a HuggingFace account** — link to huggingface.co/join
+2. **Accept the model license** — link to pyannote/speaker-diarization-community-1
+3. **Create an access token** — link to huggingface.co/settings/tokens, notes "Read" permission
+4. **Paste your token** — QLineEdit with password echo mode
+5. **Enable diarization** — checkbox, pre-checked when saving
+
+Buttons: "Skip" (close without saving) and "Save & Enable" (save token + enable flag).
+
+## Launch Points
+
+1. **Auto on first launch** — when no HF token is configured (after system status check)
+2. **Help menu** — "Diarization Setup..." always available
+3. **Settings dialog** — "Setup Wizard..." button in diarization section
+
+## Bug Fixes
+
+- `settings_dialog.py`: model link `speaker-diarization-3.1` → `speaker-diarization-community-1`
+- `dependency_checker.py`: cache path `speaker-diarization-3.1` → `speaker-diarization-community-1`
+
+## YAGNI Exclusions
+
+- No token verification API call
+- No multi-page wizard with Next/Back
+- No step completion tracking

--- a/resources/style.qss
+++ b/resources/style.qss
@@ -9,7 +9,7 @@ QWidget {
     background-color: #1e1e2e;
     color: #cdd6f4;
     font-family: "Segoe UI", sans-serif;
-    font-size: 13px;
+    font-size: 10pt;
 }
 
 /* Menu Bar */
@@ -130,7 +130,7 @@ QComboBox QAbstractItemView {
     color: #cdd6f4;
     border: 1px solid #45475a;
     selection-background-color: #45475a;
-    font-size: 13px;
+    font-size: 10pt;
 }
 
 QComboBox QAbstractItemView::item {
@@ -195,6 +195,50 @@ QListWidget::item:selected {
 
 QListWidget::item:hover {
     background-color: #313244;
+}
+
+/* Capture mode radio buttons */
+QRadioButton#captureMode {
+    background-color: #181825;
+    border: 1px solid #313244;
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-weight: bold;
+    font-size: 13px;
+    spacing: 8px;
+}
+
+QRadioButton#captureMode:checked {
+    border-color: #89b4fa;
+    color: #89b4fa;
+}
+
+QRadioButton#captureMode:hover {
+    border-color: #585b70;
+    background-color: #1e1e2e;
+}
+
+QRadioButton#captureMode::indicator {
+    width: 14px;
+    height: 14px;
+    border-radius: 7px;
+    border: 2px solid #45475a;
+    background-color: #313244;
+}
+
+QRadioButton#captureMode::indicator:checked {
+    background-color: #89b4fa;
+    border-color: #89b4fa;
+}
+
+/* Compact app audio list */
+#appAudioList {
+    padding: 2px;
+}
+
+#appAudioList::item {
+    padding: 2px 6px;
+    margin: 0px;
 }
 
 /* Tabs */
@@ -414,4 +458,65 @@ QToolTip {
 
 #speakerPanelToggle:hover {
     color: #b4d0fb;
+}
+
+/* Diarization Setup Wizard */
+#wizardHeader {
+    font-size: 18px;
+    font-weight: bold;
+    color: #cdd6f4;
+    margin-bottom: 4px;
+}
+
+#wizardStep {
+    background-color: #181825;
+    border: 1px solid #313244;
+    border-radius: 8px;
+}
+
+#wizardStepNumber {
+    background-color: #89b4fa;
+    color: #1e1e2e;
+    font-size: 14px;
+    font-weight: bold;
+    border-radius: 16px;
+}
+
+#wizardStepTitle {
+    font-size: 13px;
+    font-weight: bold;
+    color: #cdd6f4;
+}
+
+#wizardStepDesc {
+    font-size: 12px;
+    color: #a6adc8;
+}
+
+#wizardActionBtn {
+    background-color: #313244;
+    color: #89b4fa;
+    border: 1px solid #45475a;
+    border-radius: 6px;
+    padding: 6px 14px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+#wizardActionBtn:hover {
+    background-color: #45475a;
+    border-color: #89b4fa;
+}
+
+#wizardSaveBtn {
+    background-color: #89b4fa;
+    color: #1e1e2e;
+    font-weight: bold;
+    border: none;
+    border-radius: 8px;
+    padding: 8px 16px;
+}
+
+#wizardSaveBtn:hover {
+    background-color: #b4d0fb;
 }

--- a/resources/style.qss
+++ b/resources/style.qss
@@ -364,3 +364,54 @@ QToolTip {
     font-size: 12px;
     font-style: italic;
 }
+
+/* Recording Header */
+#recordingName {
+    font-size: 16px;
+    font-weight: bold;
+    color: #cdd6f4;
+}
+
+#recordingNameEdit {
+    font-size: 16px;
+    font-weight: bold;
+}
+
+#recordingInfo {
+    color: #a6adc8;
+    font-size: 12px;
+}
+
+#renameButton {
+    padding: 4px 12px;
+    font-size: 12px;
+    min-height: 16px;
+}
+
+/* Segment Widget */
+#segmentPlayBtn {
+    font-size: 11px;
+    border-radius: 14px;
+    background-color: #313244;
+    border: 1px solid #45475a;
+    padding: 0;
+}
+
+#segmentPlayBtn:hover {
+    background-color: #45475a;
+}
+
+/* Speaker Name Panel */
+#speakerPanelToggle {
+    text-align: left;
+    font-weight: bold;
+    color: #89b4fa;
+    font-size: 13px;
+    padding: 4px 0;
+    border: none;
+    background: transparent;
+}
+
+#speakerPanelToggle:hover {
+    color: #b4d0fb;
+}

--- a/start.bat
+++ b/start.bat
@@ -1,5 +1,4 @@
 @echo off
-title TalkTrack
 cd /d "%~dp0"
-python main.py
-pause
+start "" pythonw main.py
+

--- a/start.ps1
+++ b/start.ps1
@@ -1,2 +1,2 @@
 Set-Location $PSScriptRoot
-python main.py
+Start-Process pythonw main.py

--- a/tests/test_recording_header.py
+++ b/tests/test_recording_header.py
@@ -1,0 +1,36 @@
+"""Tests for RecordingHeader widget."""
+import unittest
+
+
+class TestRecordingHeaderHelpers(unittest.TestCase):
+
+    def test_display_name_from_metadata_with_name(self):
+        from app.ui.recording_header import _display_name_from_metadata
+        metadata = {"name": "Sprint Planning", "directory": "C:/recordings/rec_2024"}
+        self.assertEqual(_display_name_from_metadata(metadata), "Sprint Planning")
+
+    def test_display_name_falls_back_to_directory(self):
+        from app.ui.recording_header import _display_name_from_metadata
+        metadata = {"directory": "C:/recordings/recording_20240308_1430"}
+        self.assertEqual(_display_name_from_metadata(metadata), "recording_20240308_1430")
+
+    def test_display_name_empty_name_falls_back(self):
+        from app.ui.recording_header import _display_name_from_metadata
+        metadata = {"name": "", "directory": "C:/recordings/my_rec"}
+        self.assertEqual(_display_name_from_metadata(metadata), "my_rec")
+
+    def test_format_duration_zero(self):
+        from app.ui.recording_header import _format_duration
+        self.assertEqual(_format_duration(0), "0s")
+
+    def test_format_duration_minutes(self):
+        from app.ui.recording_header import _format_duration
+        self.assertEqual(_format_duration(65), "1m 5s")
+
+    def test_format_duration_hours(self):
+        from app.ui.recording_header import _format_duration
+        self.assertEqual(_format_duration(3661), "1h 1m 1s")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_segment_player.py
+++ b/tests/test_segment_player.py
@@ -1,0 +1,82 @@
+"""Tests for SegmentPlayer audio clip playback."""
+import unittest
+from unittest.mock import patch, MagicMock
+import numpy as np
+
+
+class TestSegmentPlayer(unittest.TestCase):
+
+    @patch("app.audio.segment_player.sf")
+    @patch("app.audio.segment_player.sd")
+    def test_play_segment_extracts_correct_samples(self, mock_sd, mock_sf):
+        """Playing from 1.0s to 2.0s at 16000Hz should extract samples 16000-32000."""
+        from app.audio.segment_player import SegmentPlayer
+
+        audio_data = np.zeros(80000, dtype=np.float32)
+        mock_sf.read.return_value = (audio_data, 16000)
+
+        player = SegmentPlayer()
+        player.play_segment("test.wav", 1.0, 2.0)
+
+        mock_sd.play.assert_called_once()
+        played_data = mock_sd.play.call_args[0][0]
+        self.assertEqual(len(played_data), 16000)
+        self.assertEqual(mock_sd.play.call_args[1]["samplerate"], 16000)
+
+    @patch("app.audio.segment_player.sf")
+    @patch("app.audio.segment_player.sd")
+    def test_stop_calls_sounddevice_stop(self, mock_sd, mock_sf):
+        from app.audio.segment_player import SegmentPlayer
+
+        player = SegmentPlayer()
+        player.stop()
+        mock_sd.stop.assert_called_once()
+
+    @patch("app.audio.segment_player.sf")
+    @patch("app.audio.segment_player.sd")
+    def test_play_segment_caches_audio_file(self, mock_sd, mock_sf):
+        """Loading the same file twice should only call sf.read once."""
+        from app.audio.segment_player import SegmentPlayer
+
+        audio_data = np.zeros(80000, dtype=np.float32)
+        mock_sf.read.return_value = (audio_data, 16000)
+
+        player = SegmentPlayer()
+        player.play_segment("test.wav", 0.0, 1.0)
+        player.play_segment("test.wav", 1.0, 2.0)
+
+        self.assertEqual(mock_sf.read.call_count, 1)
+
+    @patch("app.audio.segment_player.sf")
+    @patch("app.audio.segment_player.sd")
+    def test_play_segment_stops_previous_before_playing(self, mock_sd, mock_sf):
+        from app.audio.segment_player import SegmentPlayer
+
+        audio_data = np.zeros(80000, dtype=np.float32)
+        mock_sf.read.return_value = (audio_data, 16000)
+
+        player = SegmentPlayer()
+        player.play_segment("test.wav", 0.0, 1.0)
+        player.play_segment("test.wav", 1.0, 2.0)
+
+        # stop() called before each play
+        self.assertEqual(mock_sd.stop.call_count, 2)
+
+    @patch("app.audio.segment_player.sf")
+    @patch("app.audio.segment_player.sd")
+    def test_play_clamps_to_audio_length(self, mock_sd, mock_sf):
+        """End time beyond audio length should clamp to end of file."""
+        from app.audio.segment_player import SegmentPlayer
+
+        audio_data = np.zeros(16000, dtype=np.float32)  # 1 second
+        mock_sf.read.return_value = (audio_data, 16000)
+
+        player = SegmentPlayer()
+        player.play_segment("test.wav", 0.5, 5.0)
+
+        played_data = mock_sd.play.call_args[0][0]
+        self.assertEqual(len(played_data), 8000)  # only 0.5s available
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_segment_widget.py
+++ b/tests/test_segment_widget.py
@@ -1,0 +1,41 @@
+"""Tests for SegmentWidget logic."""
+import unittest
+from app.transcription.transcriber import TranscriptSegment
+
+
+class TestSegmentWidgetHelpers(unittest.TestCase):
+
+    def test_format_time(self):
+        from app.ui.segment_widget import _format_time
+        self.assertEqual(_format_time(0), "00:00:00")
+        self.assertEqual(_format_time(65), "00:01:05")
+        self.assertEqual(_format_time(3661), "01:01:01")
+
+    def test_display_speaker_with_name(self):
+        from app.ui.segment_widget import _display_speaker
+        self.assertEqual(
+            _display_speaker("SPEAKER_00", {"SPEAKER_00": "Alice"}),
+            "Alice"
+        )
+
+    def test_display_speaker_without_name(self):
+        from app.ui.segment_widget import _display_speaker
+        self.assertEqual(
+            _display_speaker("SPEAKER_00", {}),
+            "SPEAKER_00"
+        )
+
+    def test_display_speaker_empty(self):
+        from app.ui.segment_widget import _display_speaker
+        self.assertEqual(_display_speaker("", {}), "")
+
+    def test_display_speaker_empty_name_value(self):
+        from app.ui.segment_widget import _display_speaker
+        self.assertEqual(
+            _display_speaker("SPEAKER_00", {"SPEAKER_00": ""}),
+            "SPEAKER_00"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_speaker_name_panel.py
+++ b/tests/test_speaker_name_panel.py
@@ -1,0 +1,26 @@
+"""Tests for SpeakerNamePanel logic."""
+import unittest
+
+
+class TestSpeakerNamePanelLogic(unittest.TestCase):
+
+    def test_build_speaker_list_from_segments(self):
+        """Extract unique sorted speakers from segments."""
+        from app.ui.speaker_name_panel import _extract_speakers
+        from app.transcription.transcriber import TranscriptSegment
+        segments = [
+            TranscriptSegment(start=0, end=1, text="a", speaker="SPEAKER_01"),
+            TranscriptSegment(start=1, end=2, text="b", speaker="SPEAKER_00"),
+            TranscriptSegment(start=2, end=3, text="c", speaker="SPEAKER_01"),
+            TranscriptSegment(start=3, end=4, text="d", speaker=""),
+        ]
+        speakers = _extract_speakers(segments)
+        self.assertEqual(speakers, ["SPEAKER_00", "SPEAKER_01"])
+
+    def test_build_speaker_list_empty_segments(self):
+        from app.ui.speaker_name_panel import _extract_speakers
+        self.assertEqual(_extract_speakers([]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -1,0 +1,39 @@
+"""Tests for TranscriptSegment and TranscriptResult."""
+import unittest
+from app.transcription.transcriber import TranscriptSegment, TranscriptResult
+
+
+class TestTranscriptSegment(unittest.TestCase):
+
+    def test_to_dict_without_original_text(self):
+        seg = TranscriptSegment(start=1.0, end=2.0, text="hello")
+        d = seg.to_dict()
+        self.assertEqual(d["text"], "hello")
+        self.assertNotIn("original_text", d)
+
+    def test_to_dict_with_original_text(self):
+        seg = TranscriptSegment(start=1.0, end=2.0, text="Q4", original_text="quarterly")
+        d = seg.to_dict()
+        self.assertEqual(d["text"], "Q4")
+        self.assertEqual(d["original_text"], "quarterly")
+
+    def test_to_dict_with_empty_original_text_omits_it(self):
+        seg = TranscriptSegment(start=1.0, end=2.0, text="hello", original_text="")
+        d = seg.to_dict()
+        self.assertNotIn("original_text", d)
+
+    def test_from_dict_with_original_text(self):
+        """TranscriptSegment(**dict) should accept original_text."""
+        data = {"start": 1.0, "end": 2.0, "text": "Q4", "original_text": "quarterly",
+                "speaker": "", "confidence": 0.0}
+        seg = TranscriptSegment(**data)
+        self.assertEqual(seg.original_text, "quarterly")
+
+    def test_from_dict_without_original_text(self):
+        data = {"start": 1.0, "end": 2.0, "text": "hello", "speaker": "", "confidence": 0.0}
+        seg = TranscriptSegment(**data)
+        self.assertEqual(seg.original_text, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -34,6 +34,15 @@ class TestTranscriptSegment(unittest.TestCase):
         seg = TranscriptSegment(**data)
         self.assertEqual(seg.original_text, "")
 
+    def test_from_dict_ignores_unknown_keys(self):
+        """from_dict should ignore extra keys like speaker_name."""
+        data = {"start": 1.0, "end": 2.0, "text": "hello", "speaker": "SPEAKER_00",
+                "confidence": 0.9, "speaker_name": "Alice", "extra_field": 42}
+        seg = TranscriptSegment.from_dict(data)
+        self.assertEqual(seg.text, "hello")
+        self.assertEqual(seg.speaker, "SPEAKER_00")
+        self.assertFalse(hasattr(seg, "speaker_name"))
+
 
 class TestTranscriptResultExports(unittest.TestCase):
 

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -35,5 +35,60 @@ class TestTranscriptSegment(unittest.TestCase):
         self.assertEqual(seg.original_text, "")
 
 
+class TestTranscriptResultExports(unittest.TestCase):
+
+    def _make_result(self):
+        return TranscriptResult(
+            segments=[
+                TranscriptSegment(start=0.0, end=5.0, text="Hello everyone", speaker="SPEAKER_00"),
+                TranscriptSegment(start=5.0, end=10.0, text="Hi there", speaker="SPEAKER_01"),
+            ],
+            language="en",
+            duration=10.0,
+        )
+
+    def test_to_text_without_speaker_names(self):
+        result = self._make_result()
+        text = result.to_text()
+        self.assertIn("[SPEAKER_00]", text)
+        self.assertIn("[SPEAKER_01]", text)
+
+    def test_to_text_with_speaker_names(self):
+        result = self._make_result()
+        names = {"SPEAKER_00": "Alice", "SPEAKER_01": "Bob"}
+        text = result.to_text(speaker_names=names)
+        self.assertIn("[Alice]", text)
+        self.assertIn("[Bob]", text)
+        self.assertNotIn("SPEAKER_00", text)
+
+    def test_to_text_with_partial_speaker_names(self):
+        result = self._make_result()
+        names = {"SPEAKER_00": "Alice"}
+        text = result.to_text(speaker_names=names)
+        self.assertIn("[Alice]", text)
+        self.assertIn("[SPEAKER_01]", text)
+
+    def test_to_srt_with_speaker_names(self):
+        result = self._make_result()
+        names = {"SPEAKER_00": "Alice"}
+        srt = result.to_srt(speaker_names=names)
+        self.assertIn("[Alice]", srt)
+        self.assertIn("[SPEAKER_01]", srt)
+
+    def test_to_dict_with_speaker_names(self):
+        result = self._make_result()
+        names = {"SPEAKER_00": "Alice", "SPEAKER_01": "Bob"}
+        d = result.to_dict(speaker_names=names)
+        self.assertEqual(d["segments"][0]["speaker_name"], "Alice")
+        self.assertEqual(d["segments"][1]["speaker_name"], "Bob")
+        # Original speaker IDs preserved
+        self.assertEqual(d["segments"][0]["speaker"], "SPEAKER_00")
+
+    def test_to_dict_without_speaker_names_has_no_speaker_name_key(self):
+        result = self._make_result()
+        d = result.to_dict()
+        self.assertNotIn("speaker_name", d["segments"][0])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `original_text` field to `TranscriptSegment` for inline edit undo support
- Add `speaker_names` parameter to all transcript export methods (`to_text`, `to_srt`, `to_dict`) for friendly speaker name mapping
- Add `SegmentPlayer` for per-segment audio clip playback via sounddevice
- Add `RecordingHeader` widget showing recording name, date, duration with inline rename
- Add `SpeakerNamePanel` collapsible widget for mapping speaker IDs to friendly names
- Add `SegmentWidget` interactive transcript row with play button, inline editing, and speaker click

## What's included
These are the building-block components for the full transcript enhancement suite. The data layer and all new widgets are complete with tests (55 total, all passing).

## What's remaining (follow-up PR)
- Task 7: `TranscriptViewer` rewrite to use the new components
- Task 8: `MainWindow` integration (wiring signals, load/save speaker_names.json)
- Task 9: `RecordingsList` friendly name display
- Task 10: Stylesheet updates
- Task 11: Manual integration testing

Full implementation plan: `docs/plans/2026-03-08-transcript-enhancement-plan.md`

## Test plan
- [x] All 55 unit tests pass (`python -m pytest tests/ -v`)
- [x] No regressions to existing 26 tests
- [ ] Manual integration testing (after Tasks 7-11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)