### PR TITLE
Add large-v3-turbo to the Whisper model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Choose a model in **Settings > Transcription** based on your speed/accuracy need
 | `small` | ~480 MB | Moderate | Better | ~2 GB |
 | `medium` | ~1.5 GB | Slow | Great | ~5 GB |
 | `large-v3` | ~3 GB | Slowest | Best | ~10 GB |
+| `large-v3-turbo` | ~1.6 GB | Fast | Near-best | ~6 GB |
 
 Models are downloaded automatically on first use and cached locally. No internet is needed after the initial download.
 
@@ -236,7 +237,7 @@ Access via the gear icon or **Edit > Settings**:
 
 | Setting | Options | Default |
 |---------|---------|---------|
-| Whisper Model | tiny, base, small, medium, large-v3 | small |
+| Whisper Model | tiny, base, small, medium, large-v3, large-v3-turbo | small |
 | Compute Device | CPU, CUDA (NVIDIA GPU) | CPU |
 | Language | Auto-detect, or specify (en, es, etc.) | Auto-detect |
 | Sample Rate | 16000, 22050, 44100, 48000 Hz | 16000 |

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -212,6 +212,7 @@ class SettingsDialog(QDialog):
         self.model_combo.addItem("small (balanced)", "small")
         self.model_combo.addItem("medium (slower, better accuracy)", "medium")
         self.model_combo.addItem("large-v3 (slowest, best accuracy)", "large-v3")
+        self.model_combo.addItem("large-v3-turbo (near large-v3 accuracy, much faster)", "large-v3-turbo")
         whisper_form.addRow("Model Size:", self.model_combo)
 
         self.device_combo = QComboBox()


### PR DESCRIPTION
Closes #44.

## Summary

Adds `large-v3-turbo` to the Whisper model list in Settings → Transcription. faster-whisper
already accepts this model name; TalkTrack just didn't offer it in the UI.

`large-v3-turbo` has 4 decoder layers vs `large-v3`'s 32, giving several times faster decode
for roughly a ~0.3% WER difference — a strong default for users who want near-`large-v3`
accuracy without the full decode cost. First use downloads the model (~1.6 GB) and caches it
locally like the other models.

## Changes

- `app/ui/settings_dialog.py` — new combo item after `large-v3`.
- `README.md` — new row in the Whisper Models table and updated Settings table.

## Testing

- Launched the app, opened Settings → Transcription, selected **large-v3-turbo**, and
  transcribed a short recording end-to-end.
- Verified the setting round-trips (persists to `~/.talktrack/settings.json` and reloads).
- Hardware: Intel Core Ultra 5 225H, **CPU int8** inference, Windows 11.
- `python -m pytest tests/ -v` — full suite green.

No behavior change for existing models; this is purely an added option.
