### PR TITLE
Use int8 on pre-Volta GPUs instead of float16 (fixes CUDA on Pascal)

### DIFF
--- a/app/transcription/transcriber.py
+++ b/app/transcription/transcriber.py
@@ -173,7 +173,20 @@ class TranscriptionWorker(QThread):
                     self.progress.emit("PyTorch not found — falling back to CPU.")
                     device = "cpu"
 
-            compute_type = "float16" if device == "cuda" else "int8"
+            if device == "cuda":
+                compute_type = "float16"
+                try:
+                    import torch
+                    major, _ = torch.cuda.get_device_capability()
+                    if major < 7:  # pre-Volta (Pascal and older): no efficient fp16, but int8 works (DP4A)
+                        compute_type = "int8"
+                        self.progress.emit(
+                            "GPU is pre-Volta — using int8 compute (float16 unsupported)."
+                        )
+                except Exception:
+                    pass  # keep float16; worst case the existing error surfaces
+            else:
+                compute_type = "int8"
             model = _get_model(self.model_size, device, compute_type)
 
             if self._cancel_requested:

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -67,6 +67,61 @@ class TestRunSegmentMapping(unittest.TestCase):
         self.assertNotIn("word_timestamps", kwargs)
 
 
+class TestComputeTypeSelection(unittest.TestCase):
+    """compute_type is int8 on CPU and on pre-Volta GPUs; float16 only on Volta+."""
+
+    def _run(self, device, torch_module=None):
+        fw = _FwMocks()
+        captured = {}
+
+        def fake_get_model(model_size, dev, compute_type):
+            captured["device"] = dev
+            captured["compute_type"] = compute_type
+            return fw.model
+
+        mods = {"faster_whisper": fw.module}
+        if torch_module is not None:
+            mods["torch"] = torch_module
+        with patch.dict(sys.modules, mods):
+            import app.transcription.transcriber as tr
+            with patch.object(tr, "_get_model", side_effect=fake_get_model):
+                worker = tr.TranscriptionWorker(
+                    "a.wav", model_size="base", device=device
+                )
+                messages = []
+                worker.progress.connect(messages.append)
+                worker.run()
+        return captured, messages
+
+    def _torch(self, available=True, capability=(7, 0)):
+        t = MagicMock()
+        t.cuda.is_available.return_value = available
+        t.cuda.get_device_capability.return_value = capability
+        return t
+
+    def test_cpu_uses_int8(self):
+        captured, _ = self._run("cpu")
+        self.assertEqual(captured["device"], "cpu")
+        self.assertEqual(captured["compute_type"], "int8")
+
+    def test_cuda_volta_or_newer_uses_float16(self):
+        captured, _ = self._run("cuda", self._torch(capability=(7, 0)))
+        self.assertEqual(captured["device"], "cuda")
+        self.assertEqual(captured["compute_type"], "float16")
+
+    def test_cuda_pre_volta_falls_back_to_int8(self):
+        captured, messages = self._run("cuda", self._torch(capability=(6, 1)))
+        self.assertEqual(captured["device"], "cuda")
+        self.assertEqual(captured["compute_type"], "int8")
+        self.assertTrue(any("pre-Volta" in m for m in messages))
+
+    def test_cuda_capability_probe_failure_keeps_float16(self):
+        t = self._torch()
+        t.cuda.get_device_capability.side_effect = RuntimeError("no driver")
+        captured, _ = self._run("cuda", t)
+        self.assertEqual(captured["compute_type"], "float16")
+
+
 class TestTranscriptSegment(unittest.TestCase):
 
     def test_to_dict_without_original_text(self):


### PR DESCRIPTION
Closes #45.

## Summary

`transcriber.py` hardcodes `float16` whenever the compute device is `cuda`:

```python
compute_type = "float16" if device == "cuda" else "int8"
```

CTranslate2 (faster-whisper's backend) rejects `float16` on pre-Volta NVIDIA GPUs
(Pascal / GTX 10xx and older), failing transcription with:

> target device does not support efficient float16 computation

This makes the CUDA option unusable on those cards even though `int8` works fine on them
(Pascal supports DP4A int8). This PR adds a compute-capability check: pre-Volta GPUs
(compute capability major < 7) fall back to `int8` and surface a one-line progress note;
Volta and newer keep `float16`. If the capability probe fails for any reason we keep the
existing `float16` behavior so the current error still surfaces rather than being masked.

The model cache key already includes `compute_type`, so no cache changes are needed.

## Changes

- `app/transcription/transcriber.py` — replace the one-line ternary with a capability check.

## Testing

Reproduced on a **GTX 1080 (Pascal, compute capability 6.1)**, Windows 11, CUDA 12.6
PyTorch, faster-whisper 1.2.1 / CTranslate2 4.8.1.

CTranslate2's supported CUDA compute types on this device — note `float16` is absent:

```
ct2 supported compute types (cuda): {'int8_float32', 'int8', 'float32'}
```

`TranscriptionWorker(device="cuda")` before vs after, same machine:

```
# master (old code, hardcoded float16):
ERROR: Transcription failed: Requested float16 compute type, but the target device
       or backend do not support efficient float16 computation.
# -> transcription fails, no result

# this PR (cuda-compute-type-fallback):
Loading transcription model...
GPU is pre-Volta — using int8 compute (float16 unsupported).
Transcribing audio...
Transcription complete.
# -> succeeds on int8
```

- **Unit tests:** `python -m pytest tests/ -v` green, including 4 new tests covering the
  CPU / Volta+ / pre-Volta / probe-failure branches (torch mocked).
- The pre-fix failure is a hard `ValueError` from CTranslate2 (not a silent fallback), so
  the old CUDA path is genuinely unusable on pre-Volta cards; this PR makes it work.
