### PR TITLE
Run pyannote diarization on the GPU when CUDA is available (17.5x faster)

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -868,6 +868,7 @@ class MainWindow(QMainWindow):
         hf_token = self.config.get("diarization", "hf_token")
         min_speakers = self.config.get("diarization", "min_speakers")
         max_speakers = self.config.get("diarization", "max_speakers")
+        device = self.config.get("transcription", "device")
 
         self._diarization_worker = DiarizationWorker(
             audio_path=audio_path,
@@ -875,6 +876,7 @@ class MainWindow(QMainWindow):
             hf_token=hf_token,
             min_speakers=min_speakers,
             max_speakers=max_speakers,
+            device=device,
         )
         self._diarization_worker.session = session
         self._diarization_worker.progress.connect(self._on_transcription_progress)

--- a/app/transcription/diarizer.py
+++ b/app/transcription/diarizer.py
@@ -4,21 +4,44 @@ from PyQt6.QtCore import QThread, pyqtSignal
 
 from app.transcription.transcriber import TranscriptResult, TranscriptSegment
 
-# Loaded pyannote pipelines keyed by HF token. from_pretrained costs many
-# seconds; the pipeline stays resident between recordings by design.
+# Loaded pyannote pipelines keyed by (HF token, resolved device). from_pretrained
+# costs many seconds; the pipeline stays resident between recordings by design.
+# A CPU pipeline and a CUDA pipeline are distinct objects, hence the device in the key.
 _PIPELINE_CACHE = {}
 _PIPELINE_CACHE_LOCK = threading.Lock()
 
 
-def _get_pipeline(hf_token):
+def _resolve_device(device):
+    """Map a requested device to one torch can actually use, else 'cpu'.
+
+    pyannote uses fp32, so there is no pre-Volta float16 concern here (unlike
+    CTranslate2 in the transcriber). CUDA just needs to be available.
+    """
+    if device == "cuda":
+        try:
+            import torch
+            if torch.cuda.is_available():
+                return "cuda"
+        except Exception:
+            pass
+    return "cpu"
+
+
+def _get_pipeline(hf_token, device="cpu"):
+    resolved = _resolve_device(device)
+    key = (hf_token, resolved)
     with _PIPELINE_CACHE_LOCK:
-        if hf_token not in _PIPELINE_CACHE:
+        if key not in _PIPELINE_CACHE:
             from pyannote.audio import Pipeline
-            _PIPELINE_CACHE[hf_token] = Pipeline.from_pretrained(
+            pipeline = Pipeline.from_pretrained(
                 "pyannote/speaker-diarization-community-1",
                 token=hf_token,
             )
-        return _PIPELINE_CACHE[hf_token]
+            if resolved == "cuda":
+                import torch
+                pipeline.to(torch.device("cuda"))
+            _PIPELINE_CACHE[key] = pipeline
+        return _PIPELINE_CACHE[key]
 
 
 @dataclass
@@ -36,13 +59,14 @@ class DiarizationWorker(QThread):
     error = pyqtSignal(str)
 
     def __init__(self, audio_path, transcript_result, hf_token="",
-                 min_speakers=None, max_speakers=None):
+                 min_speakers=None, max_speakers=None, device="cpu"):
         super().__init__()
         self.audio_path = audio_path
         self.transcript_result = transcript_result
         self.hf_token = hf_token
         self.min_speakers = min_speakers
         self.max_speakers = max_speakers
+        self.device = device
 
     def run(self):
         try:
@@ -57,7 +81,9 @@ class DiarizationWorker(QThread):
                 )
                 return
 
-            pipeline = _get_pipeline(self.hf_token)
+            pipeline = _get_pipeline(self.hf_token, self.device)
+            if _resolve_device(self.device) == "cuda":
+                self.progress.emit("Running speaker diarization on GPU...")
 
             self.progress.emit("Loading audio for diarization...")
 

--- a/tests/test_diarizer.py
+++ b/tests/test_diarizer.py
@@ -89,5 +89,69 @@ class TestSimpleDiarizeWorkerExists(unittest.TestCase):
         self.assertTrue(hasattr(SimpleDiarizeWorker, "error"))
 
 
+def _fake_torch(cuda_available):
+    t = MagicMock()
+    t.cuda.is_available.return_value = cuda_available
+    t.device.side_effect = lambda d: f"device:{d}"
+    return t
+
+
+class TestPipelineDeviceSelection(unittest.TestCase):
+    """The pyannote pipeline moves to CUDA when available; CPU otherwise."""
+
+    def _get_pipeline(self, device, cuda_available):
+        pa = MagicMock()  # mocked pyannote.audio module
+        pipeline = MagicMock()
+        pa.Pipeline.from_pretrained.return_value = pipeline
+        torch_mod = _fake_torch(cuda_available)
+        with patch.dict(sys.modules, {"pyannote.audio": pa, "torch": torch_mod}):
+            import app.transcription.diarizer as dz
+            dz._PIPELINE_CACHE.clear()
+            dz._get_pipeline("tok", device)
+        return pipeline, torch_mod
+
+    def test_cuda_available_moves_pipeline_to_gpu(self):
+        pipeline, torch_mod = self._get_pipeline("cuda", cuda_available=True)
+        torch_mod.device.assert_called_with("cuda")
+        pipeline.to.assert_called_once_with("device:cuda")
+
+    def test_cuda_unavailable_falls_back_to_cpu(self):
+        pipeline, _ = self._get_pipeline("cuda", cuda_available=False)
+        pipeline.to.assert_not_called()
+
+    def test_cpu_device_stays_on_cpu(self):
+        pipeline, _ = self._get_pipeline("cpu", cuda_available=True)
+        pipeline.to.assert_not_called()
+
+    def test_pipeline_cached_per_token_and_device(self):
+        pa = MagicMock()
+        pa.Pipeline.from_pretrained.side_effect = lambda *a, **k: MagicMock()
+        with patch.dict(sys.modules, {"pyannote.audio": pa, "torch": _fake_torch(True)}):
+            import app.transcription.diarizer as dz
+            dz._PIPELINE_CACHE.clear()
+            cuda1 = dz._get_pipeline("tok", "cuda")
+            cuda2 = dz._get_pipeline("tok", "cuda")
+            cpu1 = dz._get_pipeline("tok", "cpu")
+        self.assertIs(cuda1, cuda2)      # same (token, cuda) reused
+        self.assertIsNot(cuda1, cpu1)    # different resolved device -> different pipeline
+        self.assertEqual(pa.Pipeline.from_pretrained.call_count, 2)
+
+
+class TestResolveDevice(unittest.TestCase):
+    def test_cuda_available(self):
+        with patch.dict(sys.modules, {"torch": _fake_torch(True)}):
+            import app.transcription.diarizer as dz
+            self.assertEqual(dz._resolve_device("cuda"), "cuda")
+
+    def test_cuda_unavailable(self):
+        with patch.dict(sys.modules, {"torch": _fake_torch(False)}):
+            import app.transcription.diarizer as dz
+            self.assertEqual(dz._resolve_device("cuda"), "cpu")
+
+    def test_cpu_passthrough(self):
+        import app.transcription.diarizer as dz
+        self.assertEqual(dz._resolve_device("cpu"), "cpu")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #50.

## Summary

`diarizer.py` loaded the pyannote pipeline but never moved it to a GPU, so speaker
diarization ran entirely on the CPU — even when the user selected **CUDA** and transcription
used the GPU. On long recordings the diarization step then dominates total time.

This threads the configured compute device into `DiarizationWorker` and moves the pipeline
to CUDA when available, falling back to CPU otherwise. Only the neural stages (segmentation,
embedding) move to the GPU; the final PLDA clustering stays CPU-bound regardless — but the
neural stages are the bulk of the cost on long audio.

## Changes

- `app/transcription/diarizer.py`
  - `_resolve_device(device)` — returns `"cuda"` only when `torch.cuda.is_available()`, else `"cpu"`.
  - `_get_pipeline(hf_token, device="cpu")` — moves the pipeline via `pipeline.to(torch.device("cuda"))`
    when resolved to CUDA; cache key is now `(hf_token, resolved_device)` (a CPU pipeline and a
    CUDA pipeline are distinct objects).
  - `DiarizationWorker` gains a `device` param and emits a "Running speaker diarization on GPU…" note.
- `app/main_window.py` — passes `transcription.device` from config to `DiarizationWorker`.
- `tests/test_diarizer.py` — device-selection tests (CUDA→GPU, CUDA-unavailable→CPU, CPU→CPU,
  per-device cache) with torch/pyannote mocked.

## Notes

- **No pre-Volta concern.** Unlike CTranslate2 (see the compute-type PR), pyannote uses fp32,
  which pre-Volta GPUs handle fine — verified on the GTX 1080 below.
- **Portable / non-regressive.** CUDA-less machines (Intel/AMD) resolve to CPU exactly as before.
- **Accuracy unchanged.** CPU and GPU produce the same 4-speaker result on the test recording.

## Testing

Measured on a **GTX 1080 (Pascal)**, Windows 11, CUDA 12.6 PyTorch, pyannote.audio 4.0.7,
`speaker-diarization-community-1`, on a real **21.5-minute** recording:

| Path | Wall-clock | Speakers |
|------|-----------|----------|
| CPU  | 13.32 min (799 s) | 4 |
| GPU  | **0.76 min (46 s)** | 4 |
| **Speedup** | **17.5×** | identical |

End-to-end through `DiarizationWorker(device="cuda")`: emits "Running speaker diarization on
GPU…", completes in ~52 s (incl. load), assigns SPEAKER_00–03, no errors.

- `python -m pytest tests/ -v` — full suite green (includes the new device tests).
