### PR TITLE
feat: add Groq (groq.com) as an AI assistant provider

### DIFF
--- a/.claude/rules/ai-providers.md
+++ b/.claude/rules/ai-providers.md
@@ -26,6 +26,22 @@ Conventions from issues #13, #15, #30, #31, #33, #36.
 - Search runs in `recordings_list._SearchWorker` (QThread, latest-query-wins).
 - **Per-recording embedding cache (#33)**: each recording dir gets `embeddings.npz` mapping sha1(segment text) → vector, keyed by `provider.embed_model_id`. `embedding_cache.get_corpus_vectors` embeds only cache misses and prunes stale hashes — transcript edits invalidate per segment automatically. Every provider must set `embed_model_id` (base default None = caching disabled); it MUST change whenever `embed()`'s vectors would (`st:<sentence-transformer name>` / `openai:<api model>` convention). A model-id mismatch or corrupt npz drops the whole file for that recording — never mix vectors across models.
 
+## Model IDs go stale — check the vendor's deprecation page, not its model list
+
+Shipped model IDs rot. Groq's `/docs/models` page still listed
+`llama-3.3-70b-versatile` and `llama-3.1-8b-instant` as *production* well after
+`/docs/deprecations` recorded their 2026-08-16 shutdown for free/developer tier.
+Trusting the model list alone shipped a default that 404s on the first call
+(`model_not_found`) — auth and endpoint are fine, so it reads as a key problem.
+
+- When adding or refreshing a provider's list, read the **deprecation page too**.
+- Pin the default in a test. `test_ai_provider.DECOMMISSIONED_GROQ_MODELS` +
+  `test_default_model_is_a_live_groq_model` / `test_factory_default_is_a_live_groq_model`
+  exist because the provider default and the `provider_factory` default are written
+  in two places and only the factory one is used when a config omits `model`.
+- `settings_dialog.ai_model` is `setEditable(True)` for every provider, so a user
+  can always type a newer ID — the curated list is a convenience, not a constraint.
+
 ## Error surfacing
 
 - Summarize errors go through `_on_summarize_error` → panels' `set_error()` (restores prior content when it exists). Never leave panels in `set_loading` state on failure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ TalkTrack/
       grok_provider.py                 # Grok (xAI) via OpenAI-compatible API
       gemini_provider.py               # Google Gemini API implementation
       mistral_provider.py              # Mistral AI API implementation
+      groq_provider.py                 # Groq (groq.com) API implementation
       local_provider.py                # Local model (llama-cpp-python)
       provider_factory.py              # Factory for configured provider
       summarizer.py                    # Meeting summary + action items
@@ -152,7 +153,7 @@ TalkTrack/
 - **Per-provider AI settings:** API keys and models stored separately per provider with status indicator
 - **Searchable history:** text and semantic search across all past recordings
 - **Chat with transcript:** ask AI questions about the current recording
-- **AI provider choice:** Claude, OpenAI, Grok, Gemini, Mistral, or local models via Settings > AI Assistant
+- **AI provider choice:** Claude, OpenAI, Grok, Gemini, Mistral, Groq, or local models via Settings > AI Assistant
 - **Hidden devices filter:** hide unwanted audio devices (e.g., Voicemeeter) from dropdowns
 - **Capture settings persistence:** remembers capture mode (per-app vs legacy) and selected apps
 - **Min duration filter:** skip auto-transcription for short recordings (configurable in Settings)
@@ -217,7 +218,7 @@ TalkTrack/
 
 ### AI Provider System
 - Pluggable provider abstraction: `AIProvider` base class with `complete()` and `embed()` methods
-- Six implementations: Claude, OpenAI, Grok (xAI), Gemini (Google), Mistral, Local (llama-cpp-python)
+- Seven implementations: Claude, OpenAI, Grok (xAI), Gemini (Google), Mistral, Groq (groq.com), Local (llama-cpp-python)
 - Factory pattern via `create_provider(config)` — returns configured provider or None
 - AI SDK packages installed on-demand when user selects a provider (not bundled in requirements.txt)
 - Ad-hoc installer prompts user before installing, shows progress in settings dialog
@@ -235,7 +236,7 @@ TalkTrack/
 - Audio settings: sample_rate, channels, capture_mode ("legacy" or "per_app"), selected_apps, hidden_devices, mic_count (1 or 2)
 - Audio device selection is per-session (not persisted), but capture mode and selected apps are persisted
 - Transcription settings: model size (tiny/base/small/medium/large-v3), language, compute device, min_duration
-- AI settings: provider (none/claude/openai/grok/gemini/mistral/local), provider_settings (per-provider api_key/model), auto_summarize
+- AI settings: provider (none/claude/openai/grok/gemini/mistral/groq/local), provider_settings (per-provider api_key/model), auto_summarize
 - General settings: min_recording_length, auto_record, silence_auto_stop, silence_duration
 
 ### Data Files Per Recording

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ TalkTrack is a Windows desktop app for **recording and transcribing Microsoft Te
 - **Speaker diarization** — two modes:
   - *Simple* (no setup): labels "You" vs "Remote" from mic vs system channels
   - *Full* (pyannote.audio): identifies individual speakers with a free HuggingFace token
-- **AI assistant** — optional AI-powered meeting summaries, action items, and transcript chat (supports Claude, OpenAI, Grok, Gemini, Mistral, or local models)
+- **AI assistant** — optional AI-powered meeting summaries, action items, and transcript chat (supports Claude, OpenAI, Grok, Gemini, Mistral, Groq, or local models)
 - **Per-provider AI settings** — API keys and models stored separately per provider, switch without losing config
 - **Manual AI generation** — generate or regenerate summaries and action items on demand
 - **Notes in AI context** — call notes are included in AI summary and action item generation
@@ -210,6 +210,7 @@ TalkTrack integrates with AI providers to generate meeting summaries, extract ac
 | **Grok** (xAI) | grok-3, grok-3-mini, grok-2 | `openai` |
 | **Google Gemini** | gemini-2.5-flash, gemini-2.5-pro, gemini-2.0-flash | `google-generativeai` |
 | **Mistral** | mistral-large-latest, mistral-medium, mistral-small | `mistralai` |
+| **Groq** (groq.com) | openai/gpt-oss-120b, openai/gpt-oss-20b, qwen/qwen3.6-27b | `groq` |
 | **Local** | Any GGUF model via llama-cpp-python | `llama-cpp-python` |
 
 SDK packages are **installed automatically** when you select a provider — no need to install them manually. Configure your provider and API key in **Settings > AI**.
@@ -217,7 +218,7 @@ SDK packages are **installed automatically** when you select a provider — no n
 To pre-install a provider (e.g. for offline setup), use the optional extras:
 
 ```bash
-uv sync --extra claude       # or: openai, grok, gemini, mistral, local, all-ai
+uv sync --extra claude       # or: openai, grok, gemini, mistral, groq, local, all-ai
 # without uv:  pip install ".[claude]"
 ```
 
@@ -244,7 +245,7 @@ Access via the gear icon or **Edit > Settings**:
 | Output Format | WAV, MP3 (requires FFmpeg) | WAV |
 | Capture Mode | Per-app (Win11) or System Audio | Auto-detected |
 | Diarization | Enabled/Disabled, min/max speakers | Disabled |
-| AI Provider | None, Claude, OpenAI, Grok, Gemini, Mistral, Local | None |
+| AI Provider | None, Claude, OpenAI, Grok, Gemini, Mistral, Groq, Local | None |
 | AI Model | Provider-specific model list | Varies |
 | Min Recording Length | Discard recordings shorter than N seconds | 5s |
 | Auto-Record | Start recording when selected app joins a call | Off |
@@ -297,7 +298,7 @@ python -m pytest tests/ -v
 | Audio Capture | sounddevice, WASAPI, comtypes |
 | Transcription | faster-whisper |
 | Speaker Diarization | pyannote.audio 4.0 |
-| AI Providers | anthropic, openai, google-generativeai, mistralai (on-demand) |
+| AI Providers | anthropic, openai, google-generativeai, mistralai, groq (on-demand) |
 | Deep Learning | PyTorch |
 | Audio Processing | scipy, pydub, soundfile, numpy |
 | Windows Integration | pywin32, pycaw, comtypes |

--- a/app/ai/groq_provider.py
+++ b/app/ai/groq_provider.py
@@ -1,0 +1,36 @@
+"""Groq (groq.com) API provider — GroqCloud inference via the official SDK.
+
+Not to be confused with `grok_provider.py` (Grok, xAI).
+"""
+
+from app.ai.provider import AIProvider
+
+
+class GroqProvider(AIProvider):
+    embed_model_id = "st:all-MiniLM-L6-v2"
+
+    def __init__(self, api_key: str, model: str = "openai/gpt-oss-120b"):
+        from groq import Groq
+        self._client = Groq(
+            api_key=api_key,
+            timeout=120.0,
+        )
+        self._model = model
+
+    def complete(self, prompt: str, context: str = "") -> str:
+        messages = []
+        if context:
+            messages.append({"role": "system", "content": context})
+        messages.append({"role": "user", "content": prompt})
+
+        response = self._client.chat.completions.create(
+            model=self._model,
+            messages=messages,
+        )
+        return response.choices[0].message.content
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        from app.ai.provider import get_sentence_transformer
+        model = get_sentence_transformer("all-MiniLM-L6-v2")
+        embeddings = model.encode(texts)
+        return [e.tolist() for e in embeddings]

--- a/app/ai/provider_factory.py
+++ b/app/ai/provider_factory.py
@@ -30,6 +30,13 @@ def create_provider(config: dict) -> AIProvider | None:
             model=config.get("model", "grok-3"),
         )
 
+    if provider_type == "groq":
+        from app.ai.groq_provider import GroqProvider
+        return GroqProvider(
+            api_key=config["api_key"],
+            model=config.get("model", "openai/gpt-oss-120b"),
+        )
+
     if provider_type == "gemini":
         from app.ai.gemini_provider import GeminiProvider
         return GeminiProvider(

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -298,6 +298,7 @@ class SettingsDialog(QDialog):
         self.ai_provider_combo.addItem("Grok (xAI)", "grok")
         self.ai_provider_combo.addItem("Gemini (Google)", "gemini")
         self.ai_provider_combo.addItem("Mistral", "mistral")
+        self.ai_provider_combo.addItem("Groq (GroqCloud)", "groq")
         self.ai_provider_combo.addItem("Local Model", "local")
         self.ai_provider_combo.currentIndexChanged.connect(self._on_ai_provider_changed)
         ai_form.addRow("Provider:", self.ai_provider_combo)
@@ -531,7 +532,7 @@ class SettingsDialog(QDialog):
 
         provider = self.ai_provider_combo.currentData()
         self._current_provider = provider
-        is_api = provider in ("claude", "openai", "grok", "gemini", "mistral")
+        is_api = provider in ("claude", "openai", "grok", "gemini", "mistral", "groq")
         is_local = provider == "local"
         self.ai_api_key.setVisible(is_api)
         self.ai_api_key_label.setVisible(is_api)
@@ -549,6 +550,15 @@ class SettingsDialog(QDialog):
             self.ai_model.addItems(["gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash"])
         elif provider == "mistral":
             self.ai_model.addItems(["mistral-large-latest", "mistral-medium-latest", "mistral-small-latest"])
+        elif provider == "groq":
+            # Groq shut down llama-3.3-70b-versatile / llama-3.1-8b-instant on
+            # 2026-08-16 (free + developer tier). Production text models only;
+            # the combo is editable, so any newer ID can be typed in.
+            self.ai_model.addItems([
+                "openai/gpt-oss-120b",
+                "openai/gpt-oss-20b",
+                "qwen/qwen3.6-27b",
+            ])
         elif provider == "local":
             self.ai_model.addItem("(set path below)")
 
@@ -586,7 +596,7 @@ class SettingsDialog(QDialog):
     def _update_api_key_status(self):
         """Show a status indicator for whether an API key is configured."""
         provider = self.ai_provider_combo.currentData()
-        is_api = provider in ("claude", "openai", "grok", "gemini", "mistral")
+        is_api = provider in ("claude", "openai", "grok", "gemini", "mistral", "groq")
         if not is_api:
             self.ai_key_status.setVisible(False)
             return

--- a/app/utils/package_installer.py
+++ b/app/utils/package_installer.py
@@ -13,6 +13,7 @@ PROVIDER_PACKAGES = {
     "grok": ("openai", "openai>=1.50.0", "OpenAI SDK (used by Grok)"),
     "gemini": ("google.generativeai", "google-generativeai>=0.8.0", "Google Generative AI SDK"),
     "mistral": ("mistralai", "mistralai>=1.0.0", "Mistral AI SDK"),
+    "groq": ("groq", "groq>=0.11.0", "Groq SDK"),
     "local": ("llama_cpp", "llama-cpp-python>=0.3.0", "llama.cpp Python bindings"),
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,14 @@ openai = ["openai>=1.50.0"]
 grok = ["openai>=1.50.0"]            # Grok (xAI) uses the OpenAI-compatible SDK
 gemini = ["google-generativeai>=0.8.0"]
 mistral = ["mistralai>=1.0.0"]
+groq = ["groq>=0.11.0"]              # Groq (groq.com), distinct from Grok above
 local = ["llama-cpp-python>=0.3.0"]
 all-ai = [
     "anthropic>=0.40.0",
     "openai>=1.50.0",
     "google-generativeai>=0.8.0",
     "mistralai>=1.0.0",
+    "groq>=0.11.0",
     "llama-cpp-python>=0.3.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,5 @@ sentence-transformers>=3.0.0,<6
 # openai>=1.50.0             # OpenAI, Grok (xAI)
 # google-generativeai>=0.8.0 # Google Gemini
 # mistralai>=1.0.0           # Mistral
+# groq>=0.11.0               # Groq (groq.com)
 # llama-cpp-python>=0.3.0    # Local models

--- a/tests/test_ai_provider.py
+++ b/tests/test_ai_provider.py
@@ -4,6 +4,14 @@ from unittest.mock import patch, MagicMock
 import sys
 
 
+# Shut down 2026-08-16 for free/developer tier (Groq deprecation notice of
+# 2026-06-17). Requesting one returns 404 model_not_found.
+DECOMMISSIONED_GROQ_MODELS = frozenset({
+    "llama-3.3-70b-versatile",
+    "llama-3.1-8b-instant",
+})
+
+
 class TestProviderFactory(unittest.TestCase):
     def test_create_claude_provider(self):
         mock_anthropic = MagicMock()
@@ -32,6 +40,40 @@ class TestProviderFactory(unittest.TestCase):
             config = {"provider": "openai", "api_key": "test-key", "model": "gpt-4o"}
             provider = create_provider(config)
             self.assertIsInstance(provider, OpenAIProvider)
+
+    def test_create_groq_provider(self):
+        mock_groq = MagicMock()
+        with patch.dict(sys.modules, {"groq": mock_groq}):
+            from app.ai.provider_factory import create_provider
+            import importlib
+            import app.ai.groq_provider
+            importlib.reload(app.ai.groq_provider)
+            from app.ai.groq_provider import GroqProvider
+
+            config = {"provider": "groq", "api_key": "test-key",
+                      "model": "openai/gpt-oss-120b"}
+            provider = create_provider(config)
+            self.assertIsInstance(provider, GroqProvider)
+
+    def test_groq_is_distinct_from_grok(self):
+        """Groq (groq.com) and Grok (xAI) are different providers."""
+        mock_groq = MagicMock()
+        mock_openai = MagicMock()
+        with patch.dict(sys.modules, {"groq": mock_groq, "openai": mock_openai}):
+            from app.ai.provider_factory import create_provider
+            import importlib
+            import app.ai.groq_provider
+            import app.ai.grok_provider
+            importlib.reload(app.ai.groq_provider)
+            importlib.reload(app.ai.grok_provider)
+            from app.ai.groq_provider import GroqProvider
+            from app.ai.grok_provider import GrokProvider
+
+            groq = create_provider({"provider": "groq", "api_key": "k"})
+            grok = create_provider({"provider": "grok", "api_key": "k"})
+            self.assertIsInstance(groq, GroqProvider)
+            self.assertIsInstance(grok, GrokProvider)
+            self.assertNotIsInstance(groq, GrokProvider)
 
     def test_create_unknown_provider_raises(self):
         from app.ai.provider_factory import create_provider
@@ -105,6 +147,108 @@ class TestOpenAIProvider(unittest.TestCase):
             provider = OpenAIProvider(api_key="test", model="gpt-4o")
             result = provider.complete("Summarize", "transcript")
             self.assertEqual(result, "AI response")
+
+
+class TestGroqProvider(unittest.TestCase):
+    def _provider(self, mock_groq, model="openai/gpt-oss-120b"):
+        import importlib
+        import app.ai.groq_provider
+        importlib.reload(app.ai.groq_provider)
+        from app.ai.groq_provider import GroqProvider
+        return GroqProvider(api_key="test", model=model)
+
+    def test_default_model_is_a_live_groq_model(self):
+        """Groq decommissioned llama-3.3-70b-versatile / llama-3.1-8b-instant on
+        2026-08-16; a dead default 404s on the first call (see issue below)."""
+        import importlib
+        import app.ai.groq_provider
+        import inspect
+
+        mock_groq = MagicMock()
+        with patch.dict(sys.modules, {"groq": mock_groq}):
+            importlib.reload(app.ai.groq_provider)
+            from app.ai.groq_provider import GroqProvider
+            default = inspect.signature(GroqProvider.__init__).parameters["model"].default
+
+        self.assertNotIn(default, DECOMMISSIONED_GROQ_MODELS)
+        self.assertEqual(default, "openai/gpt-oss-120b")
+
+    def test_factory_default_is_a_live_groq_model(self):
+        """provider_factory carries its own `model` default; if it drifts from the
+        provider's, a config with no explicit model 404s on the first call."""
+        import importlib
+        import app.ai.groq_provider
+        from app.ai.provider_factory import create_provider
+
+        mock_groq = MagicMock()
+        with patch.dict(sys.modules, {"groq": mock_groq}):
+            importlib.reload(app.ai.groq_provider)
+            provider = create_provider({"provider": "groq", "api_key": "test"})
+
+        self.assertNotIn(provider._model, DECOMMISSIONED_GROQ_MODELS)
+        self.assertEqual(provider._model, "openai/gpt-oss-120b")
+
+    def test_complete(self):
+        mock_groq = MagicMock()
+        mock_client = MagicMock()
+        mock_groq.Groq.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Groq response"))]
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with patch.dict(sys.modules, {"groq": mock_groq}):
+            provider = self._provider(mock_groq)
+            result = provider.complete("Summarize", "transcript")
+
+        self.assertEqual(result, "Groq response")
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertEqual(kwargs["model"], "openai/gpt-oss-120b")
+        self.assertEqual(kwargs["messages"][0]["role"], "system")
+        self.assertEqual(kwargs["messages"][0]["content"], "transcript")
+        self.assertEqual(kwargs["messages"][-1]["content"], "Summarize")
+
+    def test_complete_without_context_sends_no_system_message(self):
+        mock_groq = MagicMock()
+        mock_client = MagicMock()
+        mock_groq.Groq.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="x"))]
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with patch.dict(sys.modules, {"groq": mock_groq}):
+            provider = self._provider(mock_groq)
+            provider.complete("Just this")
+
+        messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]["role"], "user")
+
+    def test_client_gets_explicit_timeout(self):
+        """SDK defaults hang the worker and block app close (see ai-providers rule)."""
+        mock_groq = MagicMock()
+        with patch.dict(sys.modules, {"groq": mock_groq}):
+            self._provider(mock_groq)
+        kwargs = mock_groq.Groq.call_args.kwargs
+        self.assertEqual(kwargs["api_key"], "test")
+        self.assertEqual(kwargs["timeout"], 120.0)
+
+    def test_embed_model_id_set_for_cache_keying(self):
+        from app.ai.groq_provider import GroqProvider
+        self.assertEqual(GroqProvider.embed_model_id, "st:all-MiniLM-L6-v2")
+
+    def test_embed_uses_shared_sentence_transformer_cache(self):
+        mock_groq = MagicMock()
+        mock_st_module = MagicMock()
+        with patch.dict(sys.modules, {
+            "groq": mock_groq,
+            "sentence_transformers": mock_st_module,
+        }):
+            from app.ai import provider as provider_mod
+            provider_mod._SENTENCE_TRANSFORMER_CACHE.clear()
+            p = self._provider(mock_groq)
+            p.embed(["a"])
+            p.embed(["b"])
+        self.assertEqual(mock_st_module.SentenceTransformer.call_count, 1)
 
 
 class TestProviderInterface(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -1551,6 +1551,23 @@ wheels = [
 ]
 
 [[package]]
+name = "groq"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/3e/687064918e861082cb02165872bbda31269126a108a78794dae86ddadae2/groq-1.6.0.tar.gz", hash = "sha256:c4237ecf0053ba85fd926bb31cb4b178996310474b4618867994e3e40d8e3c02", size = 158424, upload-time = "2026-07-24T17:25:49.517Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/40/164338d796cf41ea5930a42023e986d8c993720bed670d5aa143e5854873/groq-1.6.0-py3-none-any.whl", hash = "sha256:fa16db582455db324adcff1b5908519474736872e28cd5c8fa2b8bef6860e12a", size = 143693, upload-time = "2026-07-24T17:25:48.2Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5204,6 +5221,7 @@ dependencies = [
 all-ai = [
     { name = "anthropic" },
     { name = "google-generativeai" },
+    { name = "groq" },
     { name = "llama-cpp-python" },
     { name = "mistralai" },
     { name = "openai" },
@@ -5226,6 +5244,9 @@ gemini = [
 ]
 grok = [
     { name = "openai" },
+]
+groq = [
+    { name = "groq" },
 ]
 local = [
     { name = "llama-cpp-python" },
@@ -5250,6 +5271,8 @@ requires-dist = [
     { name = "faster-whisper", specifier = ">=1.0.0,<2" },
     { name = "google-generativeai", marker = "extra == 'all-ai'", specifier = ">=0.8.0" },
     { name = "google-generativeai", marker = "extra == 'gemini'", specifier = ">=0.8.0" },
+    { name = "groq", marker = "extra == 'all-ai'", specifier = ">=0.11.0" },
+    { name = "groq", marker = "extra == 'groq'", specifier = ">=0.11.0" },
     { name = "llama-cpp-python", marker = "extra == 'all-ai'", specifier = ">=0.3.0" },
     { name = "llama-cpp-python", marker = "extra == 'local'", specifier = ">=0.3.0" },
     { name = "mistralai", marker = "extra == 'all-ai'", specifier = ">=1.0.0" },
@@ -5275,7 +5298,7 @@ requires-dist = [
     { name = "torchaudio", marker = "extra == 'cuda'", specifier = ">=2.0.0,<3", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "talktrack", extra = "cuda" } },
     { name = "transformers", specifier = ">=4.45.0,<6" },
 ]
-provides-extras = ["claude", "openai", "grok", "gemini", "mistral", "local", "all-ai", "cpu", "cuda"]
+provides-extras = ["claude", "openai", "grok", "gemini", "mistral", "groq", "local", "all-ai", "cpu", "cuda"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.1.1" }]


### PR DESCRIPTION
Closes #81

Adds **Groq** (groq.com / GroqCloud) as a selectable provider under Settings > AI Assistant, following the existing provider pattern.

### Keeping it distinct from Grok (xAI)

The names collide constantly, so this is separated at four levels:

- Uses the official `groq` SDK rather than Grok's OpenAI-compatible endpoint, so the two share no client construction path
- Combo label reads "Groq (GroqCloud)" and sits after Mistral, not adjacent to "Grok (xAI)"
- Module docstring cross-references `grok_provider.py`
- `test_groq_is_distinct_from_grok` asserts a `GroqProvider` is never a `GrokProvider`, and a smoke check confirms the two keep separate keys and model lists

### Model IDs come from the deprecation page, not the model list

Worth calling out, since it cost me a debugging round. Groq's `/docs/models` page still lists `llama-3.3-70b-versatile` and `llama-3.1-8b-instant` as **production** models. They are not. Groq announced deprecation on 2026-06-17 and shut both down on **2026-08-16** for free and developer tier:

```
404 - {'error': {'message': 'The model `llama-3.3-70b-versatile` does not exist
or you do not have access to it.', 'type': 'invalid_request_error',
'code': 'model_not_found'}}
```

Auth and endpoint are both fine, so it reads as an API key problem. `/docs/deprecations` is the accurate source.

Shipped list: `openai/gpt-oss-120b` (default), `openai/gpt-oss-20b`, `qwen/qwen3.6-27b`. The last is Groq's own recommended migration target for Llama 3.3 70B, but their model docs still tag it Preview, so it is offered and not defaulted. The model combo is `setEditable(True)` for every provider, so newer IDs can be typed in without a code change.

### Conventions

Follows `.claude/rules/ai-providers.md`:

- Explicit `timeout=120.0` on the client, per the 120s convention
- `embed_model_id = "st:all-MiniLM-L6-v2"`, embeddings via the shared `get_sentence_transformer` cache
- Per-provider key/model isolation through `provider_settings`
- On-demand SDK install via `PROVIDER_PACKAGES`
- `pyproject.toml` `groq` extra plus `all-ai`, `requirements.txt`, and a regenerated `uv.lock` (`uv lock --check` passes, resolves 206 packages, adds groq v1.6.0)

### Tests

Full suite green: **392 passed**.

Nothing in the suite previously asserted a provider's *default* model, which is how a decommissioned default nearly shipped. Defaults are now pinned against a `DECOMMISSIONED_GROQ_MODELS` set, covering the provider default and the `provider_factory` default separately, since they are written in two places and only the factory one applies when a config omits `model`.

### Two things for you to decide

1. This touches `.claude/rules/ai-providers.md` to document the stale-model-list gotcha. Happy to drop that hunk if you would rather own that file yourself.
2. The `groq` version floor is `>=0.11.0` to match `anthropic>=0.40.0` and friends, but the SDK resolved to 1.6.0 and has since crossed a major. Say the word if you want `>=1.0.0`.

Not verified: no live Groq API call was made against a paid or enterprise-tier key, only against the free/developer tier where the 404 above reproduced.